### PR TITLE
Fix/remove return transfer entrypoint

### DIFF
--- a/smart-contracts/contracts/lp-strategy/src/contract.rs
+++ b/smart-contracts/contracts/lp-strategy/src/contract.rs
@@ -108,7 +108,6 @@ pub fn execute(
         ExecuteMsg::AcceptReturningFunds { id } => {
             execute_accept_returning_funds(deps, &env, info, id)
         }
-        ExecuteMsg::ReturnTransfer { amount } => execute_return_funds(deps, env, info, amount),
         ExecuteMsg::CloseChannel { channel_id } => execute_close_channel(deps, channel_id),
         ExecuteMsg::Ack { ack } => execute_ack(deps, env, info, ack),
         ExecuteMsg::TryIcq {} => execute_try_icq(deps, env),
@@ -250,28 +249,6 @@ pub fn execute_ack(
         IcsAck::Result(val) => handle_succesful_ack(deps, env, msg, val),
         IcsAck::Error(err) => handle_failing_ack(deps, env, msg, err),
     }
-}
-
-pub fn execute_return_funds(
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-    amount: Uint128,
-) -> Result<Response, ContractError> {
-    let msg = transfer_batch_unbond(
-        deps.storage,
-        &env,
-        PendingReturningUnbonds {
-            unbonds: vec![ReturningUnbond {
-                amount: RawAmount::LpShares(Uint128::new(100)),
-                owner: info.sender,
-                id: String::from("1"),
-            }],
-        },
-        amount,
-    )?;
-
-    Ok(Response::new().add_submessage(msg))
 }
 
 pub fn execute_accept_returning_funds(

--- a/smart-contracts/contracts/lp-strategy/src/msg.rs
+++ b/smart-contracts/contracts/lp-strategy/src/msg.rs
@@ -235,15 +235,8 @@ pub enum ExecuteMsg {
         id: u64,
     },
     // try to close a channel where a timout occured
-    CloseChannel {
-        channel_id: String,
-    },
-    ReturnTransfer {
-        amount: Uint128,
-    },
-    Ack {
-        ack: IbcPacketAckMsg,
-    },
+    CloseChannel { channel_id: String },
+    Ack { ack: IbcPacketAckMsg },
     TryIcq {},
     Unlock {
         unlock_only: UnlockOnly,


### PR DESCRIPTION
should have been removed before launch... Anyway allowed us to test the return transfer as a sole action. Obviously bad, need to remove before first unlocks happen