### PR TITLE
Fix retry join pool

### DIFF
--- a/smart-contracts/contracts/lp-strategy/src/bond.rs
+++ b/smart-contracts/contracts/lp-strategy/src/bond.rs
@@ -73,14 +73,18 @@ pub fn batch_bond(
     let to_address = get_ica_address(storage, ICA_CHANNEL.load(storage)?)?;
 
     if let Some((amount, deposits)) = fold_bonds(storage, total_vault_value)? {
-        Ok(Some(do_transfer(
-            storage,
-            env,
-            amount,
-            transfer_chan,
-            to_address,
-            deposits,
-        )?))
+        if amount.is_zero() {
+            return Ok(None)
+        } else {
+            Ok(Some(do_transfer(
+                storage,
+                env,
+                amount,
+                transfer_chan,
+                to_address,
+                deposits,
+            )?))
+        }
     } else {
         Ok(None)
     }

--- a/smart-contracts/contracts/lp-strategy/src/bond.rs
+++ b/smart-contracts/contracts/lp-strategy/src/bond.rs
@@ -74,7 +74,7 @@ pub fn batch_bond(
 
     if let Some((amount, deposits)) = fold_bonds(storage, total_vault_value)? {
         if amount.is_zero() {
-            return Ok(None)
+            Ok(None)
         } else {
             Ok(Some(do_transfer(
                 storage,
@@ -141,10 +141,7 @@ pub fn fold_bonds(
             &item.bond_id,
             total_balance,
         )?;
-        // we do not need to include failed bonds in total as we then transfer total (but failed bonds are already in the contract)
-        // total = total
-        //     .checked_add(item.amount)
-        //     .map_err(|err| ContractError::TracedOverflowError(err, "fold_bonds".to_string()))?;
+
         REJOIN_QUEUE.push_back(
             storage,
             &OngoingDeposit {

--- a/smart-contracts/contracts/lp-strategy/src/bond.rs
+++ b/smart-contracts/contracts/lp-strategy/src/bond.rs
@@ -128,7 +128,7 @@ pub fn fold_bonds(
             FAILED_JOIN_QUEUE
                 .pop_front(storage)?
                 .ok_or(ContractError::QueueItemNotFound {
-                    queue: "bond".to_string(),
+                    queue: "failed_join".to_string(),
                 })?;
         let claim_amount = create_claim(
             storage,
@@ -137,9 +137,10 @@ pub fn fold_bonds(
             &item.bond_id,
             total_balance,
         )?;
-        total = total
-            .checked_add(item.amount)
-            .map_err(|err| ContractError::TracedOverflowError(err, "fold_bonds".to_string()))?;
+        // we do not need to include failed bonds in total as we then transfer total (but failed bonds are already in the contract)
+        // total = total
+        //     .checked_add(item.amount)
+        //     .map_err(|err| ContractError::TracedOverflowError(err, "fold_bonds".to_string()))?;
         REJOIN_QUEUE.push_back(
             storage,
             &OngoingDeposit {

--- a/smart-contracts/contracts/lp-strategy/src/execute.rs
+++ b/smart-contracts/contracts/lp-strategy/src/execute.rs
@@ -805,18 +805,8 @@ mod tests {
         let res = handle_icq_ack(deps.as_mut().storage, env, to_binary(&ibc_ack).unwrap()).unwrap();
 
         // we do NOT transfer any token here, failed bonds were already transferred to the contract before failing and stay there
-        match &res.messages[0].msg {
-            CosmosMsg::Ibc(IbcMsg::Transfer { amount, .. }) => {
-                assert_eq!(
-                    amount,
-                    &Coin {
-                        denom: "ibc/local_osmo".to_string(),
-                        amount: Uint128::zero(),
-                    }
-                );
-            }
-            _ => panic!("unexpected message type"),
-        }
+        // as we do not have any bond_queue items, we return None here
+        assert!(res.messages.is_empty());
 
         // check that the failed join queue is emptied
         assert!(FAILED_JOIN_QUEUE.is_empty(&deps.storage).unwrap());

--- a/smart-contracts/contracts/lp-strategy/src/ibc.rs
+++ b/smart-contracts/contracts/lp-strategy/src/ibc.rs
@@ -13,10 +13,10 @@ use crate::ibc_util::{
 use crate::icq::calc_total_balance;
 use crate::start_unbond::{batch_start_unbond, handle_start_unbond_ack};
 use crate::state::{
-    LpCache, OngoingDeposit, PendingBond, CHANNELS, CONFIG, IBC_LOCK, IBC_TIMEOUT_TIME,
-    ICA_CHANNEL, ICQ_CHANNEL, LP_SHARES, OSMO_LOCK, PENDING_ACK, RECOVERY_ACK, REJOIN_QUEUE,
-    SIMULATED_EXIT_RESULT, SIMULATED_EXIT_SHARES_IN, SIMULATED_JOIN_AMOUNT_IN,
-    SIMULATED_JOIN_RESULT, TIMED_OUT, TOTAL_VAULT_BALANCE, TRAPS, USABLE_COMPOUND_BALANCE,
+    LpCache, PendingBond, CHANNELS, CONFIG, IBC_LOCK, IBC_TIMEOUT_TIME, ICA_CHANNEL, ICQ_CHANNEL,
+    LP_SHARES, OSMO_LOCK, PENDING_ACK, RECOVERY_ACK, REJOIN_QUEUE, SIMULATED_EXIT_RESULT,
+    SIMULATED_EXIT_SHARES_IN, SIMULATED_JOIN_AMOUNT_IN, SIMULATED_JOIN_RESULT, TIMED_OUT,
+    TOTAL_VAULT_BALANCE, TRAPS, USABLE_COMPOUND_BALANCE,
 };
 use crate::unbond::{batch_unbond, transfer_batch_unbond, PendingReturningUnbonds};
 use cosmos_sdk_proto::cosmos::bank::v1beta1::QueryBalanceResponse;

--- a/smart-contracts/contracts/lp-strategy/src/ibc.rs
+++ b/smart-contracts/contracts/lp-strategy/src/ibc.rs
@@ -483,7 +483,6 @@ pub fn handle_icq_ack(
 
     TOTAL_VAULT_BALANCE.save(storage, &total_balance)?;
 
-    // TODO: decide if we use exit_total_pool or the UNBOND_QUEUE added amount here
     let parsed_exit_pool_out = consolidate_exit_pool_amount_into_local_denom(
         storage,
         &exit_pool_unbonds.tokens_out,

--- a/smart-contracts/contracts/lp-strategy/src/proptests.rs
+++ b/smart-contracts/contracts/lp-strategy/src/proptests.rs
@@ -30,8 +30,7 @@ mod tests {
         },
     };
     use osmosis_std::types::{
-        cosmos::base::v1beta1::Coin as OsmoCoin,
-        osmosis::{gamm::v2::QuerySpotPriceResponse, lockup::LockedResponse},
+        cosmos::base::v1beta1::Coin as OsmoCoin, osmosis::gamm::v2::QuerySpotPriceResponse,
     };
     use proptest::collection::vec;
 
@@ -248,21 +247,12 @@ mod tests {
             // simulate that we received the ICQ ACK
             let res = handle_icq_ack(deps.as_mut().storage, env, to_binary(&ibc_ack).unwrap()).unwrap();
 
-            // get the failed pending bonds total amount
-            let failed_total_amount = failed.bonds.iter().fold(Uint128::zero(), |acc, bond| {
-                let amount = match bond.raw_amount {
-                    RawAmount::LocalDenom(amount) => amount,
-                    RawAmount::LpShares(_) => panic!("unexpected lp shares"),
-                };
-                acc + amount
-            });
-
             // get the pending bonds total amount
             let pending_total_amount = pending_bonds.iter().fold(Uint128::zero(), |acc, bond| {
                 acc + bond.amount
             });
 
-            // check that the res amount matches the amount in both queues
+            // check that the res amount matches the amount in the pending queue ONLY
             // only if there are messages
             if res.messages.len() !=0 {
                 match &res.messages[0].msg {
@@ -271,7 +261,7 @@ mod tests {
                             amount,
                             &Coin {
                                 denom: "ibc/local_osmo".to_string(),
-                                amount: failed_total_amount + pending_total_amount,
+                                amount: pending_total_amount,
                             }
                         );
                     }

--- a/tests/e2e/dockerfiles/osmosis.Dockerfile
+++ b/tests/e2e/dockerfiles/osmosis.Dockerfile
@@ -23,7 +23,7 @@ RUN git lfs install
 RUN git clone https://github.com/osmosis-labs/osmosis.git
 
 # Checkout specific version
-RUN cd osmosis && git checkout v16.1.0
+RUN cd osmosis && git checkout v17.0.0
 
 # Set Work Directory to osmosis
 WORKDIR osmosis


### PR DESCRIPTION
## 1. Overview
When manually executing a Retry for join pool, we were incorrectly transferring the total amount of BOND_QUEUE & FAILED_JOIN_QUEUE. This doesn't make sense as failed bonds were already transferred and sitting idle in the contract. This is now being handled correctly and we're only transferring BOND_QUEUE total amount.

## 2. Implementation details
fold_bonds was adding BOND_QUEUE and FAILED_JOIN_QUEUE, and returned the total of these two both. I removed FAILED_JOIN_QUEUE from the total calculation as we do not want to transfer those funds. Also fixed current tests to accommodate changes.

## 3. How to test/use
cd smart-contracts && cargo test 

## 4. Checklist
- [ ] Does the Readme need to be updated?

## 5. Limitations (optional)
When we call Retry, we also want to call Bond with some tokens to guarantee sending a join_pool transaction as this is only called in the handle_transfer_ack function.

## 6. Future Work (optional)
