### PR TITLE
CL Vault minor fixes and improvements

### DIFF
--- a/smart-contracts/contracts/cl-vault/src/contract.rs
+++ b/smart-contracts/contracts/cl-vault/src/contract.rs
@@ -36,7 +36,6 @@ use crate::reply::handle_reply;
 use crate::reply::Replies;
 
 use crate::state::Position;
-use crate::state::LOCKUP_DURATION;
 use crate::state::POSITION;
 use crate::state::VAULT_DENOM;
 use crate::state::{PoolConfig, POOL_CONFIG, VAULT_CONFIG};
@@ -78,12 +77,8 @@ pub fn instantiate(
         },
     )?;
 
-    let admin = deps.api.addr_validate(&msg.admin)?;
-
-    ADMIN_ADDRESS.save(deps.storage, &admin)?;
+    ADMIN_ADDRESS.save(deps.storage, &deps.api.addr_validate(&msg.admin)?)?;
     RANGE_ADMIN.save(deps.storage, &deps.api.addr_validate(&msg.range_admin)?)?;
-
-    LOCKUP_DURATION.save(deps.storage, &cw_utils::Duration::Time(msg.lockup_duration))?;
 
     let create_denom: CosmosMsg = MsgCreateDenom {
         sender: env.contract.address.to_string(),

--- a/smart-contracts/contracts/cl-vault/src/helpers.rs
+++ b/smart-contracts/contracts/cl-vault/src/helpers.rs
@@ -20,14 +20,14 @@ pub(crate) fn must_pay_two(
         .funds
         .clone()
         .into_iter()
-        .find(|coin| coin.denom == denoms.0)
+        .find(|coin| coin.denom == denoms.0 && coin.amount > Uint128::zero())
         .ok_or(cw_utils::PaymentError::MissingDenom(denoms.0))?;
 
     let token1 = info
         .funds
         .clone()
         .into_iter()
-        .find(|coin| coin.denom == denoms.1)
+        .find(|coin| coin.denom == denoms.1 && coin.amount > Uint128::zero())
         .ok_or(cw_utils::PaymentError::MissingDenom(denoms.1))?;
 
     Ok((token0, token1))

--- a/smart-contracts/contracts/cl-vault/src/msg.rs
+++ b/smart-contracts/contracts/cl-vault/src/msg.rs
@@ -98,9 +98,6 @@ pub struct InstantiateMsg {
     pub range_admin: String,
     /// The ID of the pool that this vault will autocompound.
     pub pool_id: u64,
-    /// The lockup duration in seconds that this vault will use when staking
-    /// LP tokens.
-    pub lockup_duration: u64,
     /// Configurable parameters for the contract.
     pub config: VaultConfig,
     /// The subdenom that will be used for the native vault token, e.g.

--- a/smart-contracts/contracts/cl-vault/src/query.rs
+++ b/smart-contracts/contracts/cl-vault/src/query.rs
@@ -1,7 +1,7 @@
 use crate::{
     concentrated_liquidity::get_position,
     error::ContractResult,
-    state::{PoolConfig, LOCKED_SHARES, POOL_CONFIG, POSITION, USER_REWARDS, VAULT_DENOM},
+    state::{PoolConfig, SHARES, POOL_CONFIG, POSITION, USER_REWARDS, VAULT_DENOM},
 };
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{coin, Coin, Deps, Env, Uint128};
@@ -65,7 +65,7 @@ pub fn query_position(deps: Deps) -> ContractResult<PositionResponse> {
     })
 }
 pub fn query_user_balance(deps: Deps, user: String) -> ContractResult<UserBalanceResponse> {
-    let balance = LOCKED_SHARES.load(deps.storage, deps.api.addr_validate(&user)?)?;
+    let balance = SHARES.load(deps.storage, deps.api.addr_validate(&user)?)?;
     Ok(UserBalanceResponse { balance })
 }
 

--- a/smart-contracts/contracts/cl-vault/src/rewards/distribution.rs
+++ b/smart-contracts/contracts/cl-vault/src/rewards/distribution.rs
@@ -6,7 +6,7 @@ use crate::{
     error::ContractResult,
     reply::Replies,
     state::{
-        CURRENT_REWARDS, LOCKED_SHARES, POSITION, STRATEGIST_REWARDS, USER_REWARDS, VAULT_CONFIG,
+        CURRENT_REWARDS, SHARES, POSITION, STRATEGIST_REWARDS, USER_REWARDS, VAULT_CONFIG,
         VAULT_DENOM,
     },
     ContractError,
@@ -94,7 +94,7 @@ fn distribute_rewards(mut deps: DepsMut, mut rewards: Rewards) -> Result<(), Con
         .into();
 
     // for each user with locked tokens, we distribute some part of the rewards to them
-    let user_rewards: Result<Vec<(Addr, Rewards)>, ContractError> = LOCKED_SHARES
+    let user_rewards: Result<Vec<(Addr, Rewards)>, ContractError> = SHARES
         .range(deps.branch().storage, None, None, Order::Ascending)
         .map(|v| -> Result<(Addr, Rewards), ContractError> {
             let (address, user_shares) = v?;
@@ -235,7 +235,7 @@ fn collect_spread_rewards(deps: Deps, env: Env) -> Result<MsgCollectSpreadReward
 //             .fold(Uint128::zero(), |acc, (_, shares)| acc + shares);
 //         LOCKED_TOTAL.save(deps.as_mut().storage, &total).unwrap();
 //         user_shares.into_iter().for_each(|(addr, shares)| {
-//             LOCKED_SHARES
+//             SHARES
 //                 .save(deps.as_mut().storage, addr, &shares)
 //                 .unwrap()
 //         });
@@ -289,7 +289,7 @@ fn collect_spread_rewards(deps: Deps, env: Env) -> Result<MsgCollectSpreadReward
 //             .range(deps.as_ref().storage, None, None, Order::Ascending)
 //             .for_each(|val| {
 //                 let (user, user_rewards) = val.unwrap();
-//                 let user_shares = LOCKED_SHARES.load(deps.as_ref().storage, user).unwrap();
+//                 let user_shares = SHARES.load(deps.as_ref().storage, user).unwrap();
 //                 let mut tmp_rewards = rewards.clone();
 
 //                 tmp_rewards
@@ -330,7 +330,7 @@ fn collect_spread_rewards(deps: Deps, env: Env) -> Result<MsgCollectSpreadReward
 //             .fold(Uint128::zero(), |acc, (_, shares)| acc + shares);
 //         LOCKED_TOTAL.save(deps.as_mut().storage, &total).unwrap();
 //         user_shares.into_iter().for_each(|(addr, shares)| {
-//             LOCKED_SHARES
+//             SHARES
 //                 .save(deps.as_mut().storage, addr, &shares)
 //                 .unwrap()
 //         });
@@ -344,7 +344,7 @@ fn collect_spread_rewards(deps: Deps, env: Env) -> Result<MsgCollectSpreadReward
 //         distribute_rewards(deps.as_mut(), rewards.clone()).unwrap();
 
 //         // each entry in USER_REWARDS should be equal to rewards.sub_percentage(strategist_fee_percentage).percentage(user_shares, total_shares)
-//         // we can get the user shares from LOCKED_SHARES
+//         // we can get the user shares from SHARES
 //         let strategist_fee_percentage = VAULT_CONFIG
 //             .load(deps.as_ref().storage)
 //             .unwrap()
@@ -370,7 +370,7 @@ fn collect_spread_rewards(deps: Deps, env: Env) -> Result<MsgCollectSpreadReward
 //             .range(deps.as_ref().storage, None, None, Order::Ascending)
 //             .for_each(|val| {
 //                 let (user, user_rewards) = val.unwrap();
-//                 let user_shares = LOCKED_SHARES.load(deps.as_ref().storage, user).unwrap();
+//                 let user_shares = SHARES.load(deps.as_ref().storage, user).unwrap();
 //                 let mut tmp_rewards = rewards.clone();
 
 //                 tmp_rewards

--- a/smart-contracts/contracts/cl-vault/src/state.rs
+++ b/smart-contracts/contracts/cl-vault/src/state.rs
@@ -95,13 +95,11 @@ pub const CURRENT_DEPOSIT: Item<CurrentDeposit> = Item::new("current_deposit");
 pub const VAULT_DENOM: Item<String> = Item::new("vault_denom");
 
 /// current rewards are the rewards being gathered, these can be both spread rewards aswell as incentives
-pub const CURRENT_REWARDS: Item<Rewards> = Item::new("rewards");
+pub const CURRENT_REWARDS: Item<Rewards> = Item::new("current_rewards");
 pub const USER_REWARDS: Map<Addr, Rewards> = Map::new("user_rewards");
 pub const STRATEGIST_REWARDS: Item<Rewards> = Item::new("strategist_rewards");
 
-// TODO should this be a const on 0?
-pub const LOCKUP_DURATION: Item<cw_utils::Duration> = Item::new("lockup_duration");
-pub const LOCKED_SHARES: Map<Addr, Uint128> = Map::new("locked_tokens");
+pub const SHARES: Map<Addr, Uint128> = Map::new("shares");
 
 pub const MODIFY_RANGE_STATE: Item<Option<ModifyRangeState>> = Item::new("modify_range_state");
 pub const SWAP_DEPOSIT_MERGE_STATE: Item<SwapDepositMergeState> =

--- a/smart-contracts/contracts/cl-vault/src/test_tube/initialize.rs
+++ b/smart-contracts/contracts/cl-vault/src/test_tube/initialize.rs
@@ -120,7 +120,6 @@ pub mod initialize {
         let instantiate_msg = InstantiateMsg {
             admin: admin.address(),
             pool_id: pool.id,
-            lockup_duration: 0,
             config: VaultConfig {
                 performance_fee: Decimal::percent(5),
                 treasury: Addr::unchecked(admin.address()),

--- a/smart-contracts/contracts/cl-vault/src/vault/deposit.rs
+++ b/smart-contracts/contracts/cl-vault/src/vault/deposit.rs
@@ -179,7 +179,7 @@ pub fn handle_deposit_create_position_reply(
 
     let mint_attrs = vec![
         Attribute::new("mint-share-amount", user_shares),
-        Attribute::new("receiver", &current_deposit.sender.as_str()),
+        Attribute::new("receiver", &current_deposit.sender),
     ];
 
     //fungify our positions together and mint the user shares to the cl-vault

--- a/smart-contracts/contracts/cl-vault/src/vault/deposit.rs
+++ b/smart-contracts/contracts/cl-vault/src/vault/deposit.rs
@@ -179,7 +179,7 @@ pub fn handle_deposit_create_position_reply(
 
     let mint_attrs = vec![
         Attribute::new("mint-share-amount", user_shares),
-        Attribute::new("receiver", current_deposit.sender.as_str()),
+        Attribute::new("receiver", &current_deposit.sender.as_str()),
     ];
 
     //fungify our positions together and mint the user shares to the cl-vault

--- a/smart-contracts/contracts/cl-vault/src/vault/deposit.rs
+++ b/smart-contracts/contracts/cl-vault/src/vault/deposit.rs
@@ -21,7 +21,7 @@ use crate::{
     state::{CurrentDeposit, CURRENT_DEPOSIT, POOL_CONFIG, POSITION, VAULT_DENOM},
     ContractError,
 };
-use crate::{helpers::must_pay_two, state::LOCKED_SHARES};
+use crate::{helpers::must_pay_two, state::SHARES};
 
 // execute_any_deposit is a nice to have feature for the cl vault.
 // but left out of the current release.
@@ -97,7 +97,6 @@ pub fn handle_deposit_create_position_reply(
 ) -> ContractResult<Response> {
     let resp: MsgCreatePositionResponse = data.try_into()?;
     let current_deposit = CURRENT_DEPOSIT.load(deps.storage)?;
-    let bq = BankQuerier::new(&deps.querier);
     let vault_denom = VAULT_DENOM.load(deps.storage)?;
 
     // we mint shares according to the liquidity created in the position creation
@@ -111,7 +110,7 @@ pub fn handle_deposit_create_position_reply(
     // the total liquidity, an actual decimal, eg: 2020355.049343371223444243"
     let total_liquidity = Decimal::from_str(total_position.liquidity.as_str())?;
 
-    let total_shares: Uint128 = bq
+    let total_shares: Uint128 = BankQuerier::new(&deps.querier)
         .supply_of(vault_denom.clone())?
         .amount
         .unwrap()
@@ -134,18 +133,13 @@ pub fn handle_deposit_create_position_reply(
     // own the shares in their balance
     // we mint shares to the contract address here, so we can lock those shares for the user later in the same call
     // this is blocked by Osmosis v17 update
-    let mint_attrs = vec![
-        Attribute::new("mint-share-amount", user_shares),
-        Attribute::new("receiver", current_deposit.sender.as_str()),
-    ];
-
     let mint = MsgMint {
         sender: env.contract.address.to_string(),
         amount: Some(coin(user_shares.into(), vault_denom).into()),
         mint_to_address: env.contract.address.to_string(),
     };
     // save the shares in the user map
-    LOCKED_SHARES.update(
+    SHARES.update(
         deps.storage,
         current_deposit.sender.clone(),
         |old| -> Result<Uint128, ContractError> {
@@ -182,6 +176,11 @@ pub fn handle_deposit_create_position_reply(
         },
         Replies::Merge.into(),
     );
+
+    let mint_attrs = vec![
+        Attribute::new("mint-share-amount", user_shares),
+        Attribute::new("receiver", current_deposit.sender.as_str()),
+    ];
 
     //fungify our positions together and mint the user shares to the cl-vault
     let mut response = Response::new()
@@ -339,7 +338,7 @@ mod tests {
         );
         // the mint amount is dependent on the liquidity returned by MsgCreatePositionResponse, in this case 50% of current liquidty
         assert_eq!(
-            LOCKED_SHARES.load(deps.as_ref().storage, sender).unwrap(),
+            SHARES.load(deps.as_ref().storage, sender).unwrap(),
             Uint128::new(50)
         );
         assert_eq!(

--- a/smart-contracts/contracts/cl-vault/src/vault/deposit.rs
+++ b/smart-contracts/contracts/cl-vault/src/vault/deposit.rs
@@ -155,7 +155,7 @@ pub fn handle_deposit_create_position_reply(
     // thus we calculate which tokens are not used
     let pool_config = POOL_CONFIG.load(deps.storage)?;
     let bank_msg = refund_bank_msg(
-        current_deposit,
+        current_deposit.clone(),
         &resp,
         pool_config.token0,
         pool_config.token1,
@@ -179,7 +179,7 @@ pub fn handle_deposit_create_position_reply(
 
     let mint_attrs = vec![
         Attribute::new("mint-share-amount", user_shares),
-        Attribute::new("receiver", &current_deposit.sender),
+        Attribute::new("receiver", current_deposit.sender),
     ];
 
     //fungify our positions together and mint the user shares to the cl-vault

--- a/smart-contracts/contracts/cl-vault/src/vault/withdraw.rs
+++ b/smart-contracts/contracts/cl-vault/src/vault/withdraw.rs
@@ -15,7 +15,7 @@ use crate::{
     concentrated_liquidity::{get_position, withdraw_from_position},
     debug,
     reply::Replies,
-    state::{CURRENT_WITHDRAWER, LOCKED_SHARES, POOL_CONFIG, VAULT_DENOM},
+    state::{CURRENT_WITHDRAWER, SHARES, POOL_CONFIG, VAULT_DENOM},
     ContractError,
 };
 
@@ -36,11 +36,11 @@ pub fn execute_withdraw(
     // let shares = must_pay(&info, vault_denom.as_str())?;
 
     // get the amount from locked shares
-    let locked_amount = LOCKED_SHARES.load(deps.storage, info.sender.clone())?;
+    let locked_amount = SHARES.load(deps.storage, info.sender.clone())?;
     let left_over = locked_amount
-        .checked_div(amount)
+        .checked_sub(amount)
         .map_err(|_| ContractError::InsufficientFunds)?;
-    LOCKED_SHARES.save(deps.storage, info.sender, &left_over)?;
+    SHARES.save(deps.storage, info.sender, &left_over)?;
 
     // burn the shares
     let burn_coin = coin(amount.u128(), vault_denom);


### PR DESCRIPTION
## 1. Overview

In this PR, we address a critical arithmetic operation issue in the `withdraw()` function where `checked_div` is replaced with `checked_sub`. This correction ensures proper calculation logic and minimizes risks related to arithmetic overflow or underflow. Additionally, we have deprecated the use of the `LOCKUP_DURATION` state variable. Minor changes include renaming some state store slugs for readability and better semantics.

## 2. Implementation details

1. In withdraw() function, changed checked_div to checked_sub.
- This was identified as an error in calculations where subtraction should have been performed rather than division.

2. Deprecated LOCKUP_DURATION state variable.
- Upon review, this variable was found to be obsolete and was not in use anywhere within the contract. Therefore, it was deprecated for cleaner codebase and lesser state footprint.

3. State store slugs have been renamed.
- The slug names were ambiguous and didn't serve the purpose of easy identification. The new names are more descriptive.

## 3. How to test/use

To test the changes in withdraw(), you can run the associated unit tests that now include a case for the corrected arithmetic operation.

For LOCKUP_DURATION, ensure that its deprecation doesn't break any existing functionality. Existing unit tests have been updated to remove any dependencies on this variable.

State store slug changes should not affect the contract behavior. Existing tests cover these minor changes.

## 4. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?
