### PR TITLE
Fix/dust withdrawal

### DIFF
--- a/smart-contracts/contracts/cl-vault/src/contract.rs
+++ b/smart-contracts/contracts/cl-vault/src/contract.rs
@@ -96,7 +96,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> ContractResult<Binary> {
         cw_vault_multi_standard::VaultStandardQueryMsg::DepositRatio => todo!(),
         cw_vault_multi_standard::VaultStandardQueryMsg::PreviewRedeem { amount: _ } => todo!(),
         cw_vault_multi_standard::VaultStandardQueryMsg::TotalAssets {} => {
-            Ok(to_binary(&query_total_assets(deps, env)?)?)
+            Ok(to_binary(&query_total_assets(deps)?)?)
         }
         cw_vault_multi_standard::VaultStandardQueryMsg::TotalVaultTokenSupply {} => {
             Ok(to_binary(&query_total_vault_token_supply(deps)?)?)

--- a/smart-contracts/contracts/cl-vault/src/helpers.rs
+++ b/smart-contracts/contracts/cl-vault/src/helpers.rs
@@ -3,11 +3,13 @@ use std::str::FromStr;
 use crate::math::tick::tick_to_price;
 use crate::rewards::CoinList;
 use crate::state::{ADMIN_ADDRESS, STRATEGIST_REWARDS, USER_REWARDS};
+use crate::vault::concentrated_liquidity::{get_cl_pool_info, get_position};
 use crate::{error::ContractResult, state::POOL_CONFIG, ContractError};
 use cosmwasm_std::{
     coin, Addr, Coin, Decimal, Decimal256, Deps, DepsMut, Env, Fraction, MessageInfo,
     QuerierWrapper, Storage, Uint128, Uint256,
 };
+use osmosis_std::types::osmosis::concentratedliquidity::v1beta1::Position;
 use osmosis_std::types::osmosis::poolmanager::v1beta1::PoolmanagerQuerier;
 
 /// returns the Coin of the needed denoms in the order given in denoms
@@ -268,6 +270,137 @@ pub fn get_unused_balances(
     }
 
     Ok(balances)
+}
+
+pub fn get_max_utilization_for_ratio(
+    token0: Uint256,
+    token1: Uint256,
+    ratio: Decimal256,
+) -> Result<(Uint256, Uint256), ContractError> {
+    // maxdep1 = T0 / R
+    let max_deposit1_from_0 =
+        token0.checked_multiply_ratio(ratio.denominator(), ratio.numerator())?;
+    // maxdep0 = T1 * R
+    let max_deposit0_from_1 =
+        token1.checked_multiply_ratio(ratio.numerator(), ratio.denominator())?;
+
+    if max_deposit0_from_1 > token0 {
+        Ok((token0, max_deposit1_from_0))
+    } else if max_deposit1_from_0 > token1 {
+        Ok((max_deposit0_from_1, token1))
+    } else {
+        Ok((token0, token1))
+    }
+}
+
+pub fn get_liquidity_amount_for_unused_funds(
+    deps: DepsMut,
+    env: &Env,
+    additional_excluded_funds: (Uint128, Uint128),
+) -> Result<Decimal256, ContractError> {
+    // first get the ratio of token0:token1 in the position.
+    let p = get_position(deps.storage, &deps.querier)?;
+    // if there is no position, then we can assume that there are 0 unused funds
+    if p.position.is_none() {
+        return Ok(Decimal256::zero());
+    }
+    let position_unwrapped = p.position.unwrap();
+    let token0: Coin = p.asset0.unwrap().try_into()?;
+    let token1: Coin = p.asset1.unwrap().try_into()?;
+    let ratio = Decimal256::from_ratio(token0.amount, token1.amount);
+
+    let pool_config = POOL_CONFIG.load(deps.storage)?;
+    let pool_details = get_cl_pool_info(&deps.querier, pool_config.pool_id)?;
+
+    // then figure out based on current unused balance, what the max initial deposit could be
+    // (with the ratio, what is the max tokens we can deposit)
+    let tokens = get_unused_balances(deps.storage, &deps.querier, env)?;
+    let unused_t0: Uint256 = tokens
+        .find_coin(token0.denom)
+        .amount
+        .checked_sub(additional_excluded_funds.0)?
+        .into();
+    let unused_t1: Uint256 = tokens
+        .find_coin(token1.denom)
+        .amount
+        .checked_sub(additional_excluded_funds.1)?
+        .into();
+
+    let max_initial_deposit =
+        get_max_utilization_for_ratio(unused_t0.into(), unused_t1.into(), ratio)?;
+
+    // then figure out how much liquidity this would give us.
+    // Formula: current_position_liquidity * token0_initial_deposit_amount / token0_in_current_position
+    // EDGE CASE: what if it's a one-sided position with only token1?
+    // SOLUTION: take whichever token is greater than the other to plug into the formula 1 line above
+    let mut position_liquidity = Decimal256::from_str(&position_unwrapped.liquidity)?;
+    let max_initial_deposit_liquidity = if token0.amount > token1.amount {
+        position_liquidity
+            .checked_mul(Decimal256::new(max_initial_deposit.0))?
+            .checked_div(Decimal256::new(token0.amount.into()))?
+    } else {
+        position_liquidity
+            .checked_mul(Decimal256::new(max_initial_deposit.1))?
+            .checked_div(Decimal256::new(token1.amount.into()))?
+    };
+
+    // subtract out the max deposit from both tokens, which will leave us with only one token, lets call this leftover_balance0 or 1
+    let leftover_balance0 = unused_t0.checked_sub(max_initial_deposit.0)?;
+    let leftover_balance1 = unused_t1.checked_sub(max_initial_deposit.1)?;
+
+    // call get_single_sided_deposit_0_to_1_swap_amount or get_single_sided_deposit_1_to_0_swap_amount to see how much we would swap to enter with the rest of our funds
+    let post_swap_liquidity = if leftover_balance0 > leftover_balance1 {
+        let swap_amount = get_single_sided_deposit_0_to_1_swap_amount(
+            leftover_balance0.try_into().unwrap(),
+            position_unwrapped.lower_tick,
+            pool_details.current_tick,
+            position_unwrapped.upper_tick,
+        )?;
+
+        // subtract the resulting swap_amount from leftover_balance0 or 1, we can then use the same formula as above to get the correct liquidity amount.
+        // we are also mindful of the same edge case
+        let leftover_balance0 = leftover_balance0.checked_sub(swap_amount.into())?;
+
+        if leftover_balance0.is_zero() {
+            // in this case we need to get the expected token1 from doing a full swap, meaning we need to multiply by the spot price
+            let token1_from_swap_amount = Decimal256::new(swap_amount.into())
+                .checked_mul(tick_to_price(pool_details.current_tick)?)?;
+            position_liquidity
+                .checked_mul(token1_from_swap_amount)?
+                .checked_div(Decimal256::new(token1.amount.into()))?
+        } else {
+            position_liquidity
+                .checked_mul(Decimal256::new(leftover_balance0))?
+                .checked_div(Decimal256::new(token0.amount.into()))?
+        }
+    } else {
+        let swap_amount = get_single_sided_deposit_1_to_0_swap_amount(
+            leftover_balance1.try_into().unwrap(),
+            position_unwrapped.lower_tick,
+            pool_details.current_tick,
+            position_unwrapped.upper_tick,
+        )?;
+
+        // subtract the resulting swap_amount from leftover_balance0 or 1, we can then use the same formula as above to get the correct liquidity amount.
+        // we are also mindful of the same edge case
+        let leftover_balance1 = leftover_balance1.checked_sub(swap_amount.into())?;
+
+        if leftover_balance1.is_zero() {
+            // in this case we need to get the expected token0 from doing a full swap, meaning we need to multiply by the spot price
+            let token0_from_swap_amount = Decimal256::new(swap_amount.into())
+                .checked_div(tick_to_price(pool_details.current_tick)?)?;
+            position_liquidity
+                .checked_mul(token0_from_swap_amount)?
+                .checked_div(Decimal256::new(token0.amount.into()))?
+        } else {
+            position_liquidity
+                .checked_mul(Decimal256::new(leftover_balance1))?
+                .checked_div(Decimal256::new(token1.amount.into()))?
+        }
+    };
+
+    // add together the liquidity from the initial deposit and the swap deposit and return that
+    Ok(max_initial_deposit_liquidity.checked_add(post_swap_liquidity)?)
 }
 
 #[cfg(test)]

--- a/smart-contracts/contracts/cl-vault/src/lib.rs
+++ b/smart-contracts/contracts/cl-vault/src/lib.rs
@@ -12,8 +12,8 @@ mod vault;
 
 pub use crate::error::ContractError;
 
-// #[cfg(test)]
-// mod test_tube;
+#[cfg(test)]
+mod test_tube;
 
 #[cfg(test)]
 mod test_helpers;

--- a/smart-contracts/contracts/cl-vault/src/math/tick.rs
+++ b/smart-contracts/contracts/cl-vault/src/math/tick.rs
@@ -237,9 +237,6 @@ mod tests {
 
     #[test]
     fn test_tick_to_price() {
-        let upper = tick_to_price(100);
-        println!("{:?}", upper);
-        panic!();
         // example1
         let tick_index = 38035200;
         let expected_price = Decimal256::from_str("30352").unwrap();

--- a/smart-contracts/contracts/cl-vault/src/query.rs
+++ b/smart-contracts/contracts/cl-vault/src/query.rs
@@ -119,8 +119,8 @@ pub fn query_user_rewards(deps: Deps, user: String) -> ContractResult<UserReward
     Ok(UserRewardsResponse { rewards })
 }
 
-pub fn query_total_assets(deps: Deps, env: Env) -> ContractResult<TotalAssetsResponse> {
-    let position = get_position(deps.storage, &deps.querier, &env)?;
+pub fn query_total_assets(deps: Deps) -> ContractResult<TotalAssetsResponse> {
+    let position = get_position(deps.storage, &deps.querier)?;
     let pool = POOL_CONFIG.load(deps.storage)?;
     Ok(TotalAssetsResponse {
         token0: position

--- a/smart-contracts/contracts/cl-vault/src/state.rs
+++ b/smart-contracts/contracts/cl-vault/src/state.rs
@@ -127,6 +127,7 @@ pub struct TickExpIndexData {
 
 pub const TICK_EXP_CACHE: Map<i64, TickExpIndexData> = Map::new("tick_exp_cache");
 pub const CURRENT_WITHDRAWER: Item<Addr> = Item::new("current_withdrawer");
+pub const CURRENT_WITHDRAWER_DUST: Item<(Uint128, Uint128)> = Item::new("current_withdrawer_dust");
 
 #[cfg(test)]
 mod tests {

--- a/smart-contracts/contracts/cl-vault/src/state.rs
+++ b/smart-contracts/contracts/cl-vault/src/state.rs
@@ -62,8 +62,6 @@ pub const POSITION: Item<Position> = Item::new("position");
 
 pub const SHARES: Map<Addr, Uint128> = Map::new("shares");
 
-pub const DUST: Item<(Uint128, Uint128)> = Item::new("dust");
-
 /// The merge of positions currently being executed
 pub const CURRENT_MERGE: Deque<CurrentMergeWithdraw> = Deque::new("current_merge");
 

--- a/smart-contracts/contracts/cl-vault/src/state.rs
+++ b/smart-contracts/contracts/cl-vault/src/state.rs
@@ -62,6 +62,8 @@ pub const POSITION: Item<Position> = Item::new("position");
 
 pub const SHARES: Map<Addr, Uint128> = Map::new("shares");
 
+pub const DUST: Item<(Uint128, Uint128)> = Item::new("dust");
+
 /// The merge of positions currently being executed
 pub const CURRENT_MERGE: Deque<CurrentMergeWithdraw> = Deque::new("current_merge");
 

--- a/smart-contracts/contracts/cl-vault/src/test_helpers.rs
+++ b/smart-contracts/contracts/cl-vault/src/test_helpers.rs
@@ -1,9 +1,9 @@
 use std::marker::PhantomData;
 
-use cosmwasm_std::testing::{BankQuerier, MockStorage, MockApi, MOCK_CONTRACT_ADDR};
+use cosmwasm_std::testing::{BankQuerier, MockApi, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    from_binary, to_binary, Binary, Coin, ContractResult as CwContractResult, Empty, Querier,
-    QuerierResult, QueryRequest, MessageInfo, OwnedDeps, Decimal, Addr,
+    from_binary, to_binary, Addr, Binary, Coin, ContractResult as CwContractResult, Decimal, Empty,
+    MessageInfo, OwnedDeps, Querier, QuerierResult, QueryRequest,
 };
 use osmosis_std::types::cosmos::bank::v1beta1::{QuerySupplyOfRequest, QuerySupplyOfResponse};
 
@@ -12,12 +12,12 @@ use osmosis_std::types::osmosis::poolmanager::v1beta1::{PoolResponse, SpotPriceR
 use osmosis_std::types::{
     cosmos::base::v1beta1::Coin as OsmoCoin,
     osmosis::concentratedliquidity::v1beta1::{
-        FullPositionBreakdown, PositionByIdRequest, PositionByIdResponse, Position as OsmoPosition
+        FullPositionBreakdown, Position as OsmoPosition, PositionByIdRequest, PositionByIdResponse,
     },
 };
 
 use crate::math::tick::tick_to_price;
-use crate::state::{RANGE_ADMIN, POOL_CONFIG, PoolConfig, VAULT_CONFIG, POSITION, VaultConfig};
+use crate::state::{PoolConfig, VaultConfig, POOL_CONFIG, POSITION, RANGE_ADMIN, VAULT_CONFIG};
 pub struct QuasarQuerier {
     position: FullPositionBreakdown,
     current_tick: i64,
@@ -78,7 +78,7 @@ impl Querier for QuasarQuerier {
                             to_binary(&QuerySupplyOfResponse {
                                 amount: Some(OsmoCoin {
                                     denom,
-                                    amount: 100.to_string(),
+                                    amount: 100000.to_string(),
                                 }),
                             })
                             .unwrap(),

--- a/smart-contracts/contracts/cl-vault/src/test_tube/deposit_withdraw.rs
+++ b/smart-contracts/contracts/cl-vault/src/test_tube/deposit_withdraw.rs
@@ -1,14 +1,190 @@
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::Coin;
+    use cosmwasm_std::{coin, Coin, Uint128};
 
-    use osmosis_test_tube::{Account, Module, Wasm};
+    use osmosis_std::types::{
+        cosmos::bank::v1beta1::{MsgSend, QueryAllBalancesRequest},
+        osmosis::concentratedliquidity::v1beta1::PositionByIdRequest,
+    };
+    use osmosis_test_tube::{Account, Bank, ConcentratedLiquidity, Module, Wasm};
 
     use crate::{
         msg::{ExecuteMsg, ExtensionQueryMsg, QueryMsg},
-        query::UserBalanceResponse,
+        query::{PositionResponse, UserBalanceResponse},
         test_tube::default_init,
     };
+
+    #[test]
+    #[ignore]
+    fn multiple_deposit_withdraw_unused_funds_works() {
+        let (app, contract_address, cl_pool_id, _admin) = default_init();
+        let alice = app
+            .init_account(&[
+                Coin::new(1_000_000_000_000, "uatom"),
+                Coin::new(1_000_000_000_000, "uosmo"),
+            ])
+            .unwrap();
+        let bob = app
+            .init_account(&[
+                Coin::new(1_000_000_000_000, "uatom"),
+                Coin::new(1_000_000_000_000, "uosmo"),
+            ])
+            .unwrap();
+
+        let bank = Bank::new(&app);
+        // our initial balance, 89874uosmo
+        let balances = bank
+            .query_all_balances(&QueryAllBalancesRequest {
+                address: contract_address.to_string(),
+                pagination: None,
+            })
+            .unwrap();
+        println!("{:?}", balances);
+
+        let wasm = Wasm::new(&app);
+
+        // depositing 
+        let res = wasm
+            .execute(
+                contract_address.as_str(),
+                &ExecuteMsg::ExactDeposit { recipient: None },
+                &[Coin::new(5000, "uatom"), Coin::new(5000, "uosmo")],
+                &alice,
+            )
+            .unwrap();
+
+        // The contract right now has 89874 free uosmo, if we send another 89874 free uosmo, we double the amount of free
+        // liquidity, but we want to double the amount of total liquidity, so we first query to contract to get how many
+        // assets we have in the position
+        let pos_id: PositionResponse = wasm
+            .query(
+                contract_address.as_str(),
+                &QueryMsg::VaultExtension(ExtensionQueryMsg::ConcentratedLiquidity(
+                    crate::msg::ClQueryMsg::Position {},
+                )),
+            )
+            .unwrap();
+        let position = ConcentratedLiquidity::new(&app)
+            .query_position_by_id(&PositionByIdRequest {
+                position_id: pos_id.position_ids[0],
+            })
+            .unwrap();
+        // This amount should decrease the amount of shares we get back
+        println!("position {:?}", position);
+        // "uatom", amount: "100000" }), asset1: Some(Coin { denom: "uosmo", amount: "10126"
+        // to dilute 50%, we need to send uatom100000, 10631uosmo + 89874+uosmo = 100000uosmo
+        // aka double the liquidty
+
+        bank.send(
+            MsgSend {
+                from_address: alice.address(),
+                to_address: contract_address.to_string(),
+                amount: vec![coin(9995, "uatom").into(), coin(1012, "uosmo").into()],
+            },
+            &alice,
+        )
+        .unwrap();
+
+        let res = wasm
+            .execute(
+                contract_address.as_str(),
+                &ExecuteMsg::ExactDeposit { recipient: None },
+                &[Coin::new(5_000, "uatom"), Coin::new(5_000, "uosmo")],
+                &bob,
+            )
+            .unwrap();
+        println!("{:?}", res);
+
+        // 2766182566501133149875859 before banksend,
+        // 1926137978194597565946694 after banksend
+        // does this make sense?
+        // when we withdraw 2766182566501133149875859 shares, we should get our original amount back +
+        // 2766182566501133149875859 / total_shares * 89874 back, remember we had original free osmo
+        // and sent free osmo
+        // the second share amount should only get it's original amount back
+
+        // let _ = wasm
+        //     .execute(
+        //         contract_address.as_str(),
+        //         &ExecuteMsg::ExactDeposit { recipient: None },
+        //         &[Coin::new(5_000, "uatom"), Coin::new(5_000, "uosmo")],
+        //         &alice,
+        //     )
+        //     .unwrap();
+
+        let alice_shares: UserBalanceResponse = wasm
+            .query(
+                contract_address.as_str(),
+                &QueryMsg::VaultExtension(ExtensionQueryMsg::Balances(
+                    crate::msg::UserBalanceQueryMsg::UserSharesBalance {
+                        user: alice.address(),
+                    },
+                )),
+            )
+            .unwrap();
+        let bob_shares: UserBalanceResponse = wasm
+            .query(
+                contract_address.as_str(),
+                &QueryMsg::VaultExtension(ExtensionQueryMsg::Balances(
+                    crate::msg::UserBalanceQueryMsg::UserSharesBalance {
+                        user: bob.address(),
+                    },
+                )),
+            )
+            .unwrap();
+
+
+        let balances = bank
+            .query_all_balances(&QueryAllBalancesRequest {
+                address: contract_address.to_string(),
+                pagination: None,
+            })
+            .unwrap();
+        println!("balances-pre-w {:?}", balances);
+        let pos_id: PositionResponse = wasm
+            .query(
+                contract_address.as_str(),
+                &QueryMsg::VaultExtension(ExtensionQueryMsg::ConcentratedLiquidity(
+                    crate::msg::ClQueryMsg::Position {},
+                )),
+            )
+            .unwrap();
+        let position = ConcentratedLiquidity::new(&app)
+            .query_position_by_id(&PositionByIdRequest {
+                position_id: pos_id.position_ids[0],
+            })
+            .unwrap();
+        // This amount should decrease the amount of shares we get back
+        println!("position-pre-w {:?}", position);
+
+        let withdraw = wasm
+            .execute(
+                contract_address.as_str(),
+                &ExecuteMsg::Redeem {
+                    recipient: None,
+                    amount: bob_shares.balance,
+                },
+                &[],
+                &bob,
+            )
+            .unwrap();
+        println!("w_low {:?}", withdraw);
+
+        let withdraw = wasm
+            .execute(
+                contract_address.as_str(),
+                &ExecuteMsg::Redeem {
+                    recipient: None,
+                    amount: alice_shares.balance,
+                },
+                &[],
+                &alice,
+            )
+            .unwrap();
+        println!("w_up {:?}", withdraw);
+        // we receive "token0_amount", value: "2018" }, Attribute { key: "token1_amount", value: "3503
+        // we used 5000uatom to deposit and 507 uosmo, thus we are down 3000 uatom and up 2996 uosmo
+    }
 
     #[test]
     #[ignore]
@@ -97,8 +273,8 @@ mod tests {
                 &alice,
             )
             .unwrap();
+        println!("{:?}", deposit);
 
-        let _mint = deposit.events.iter().find(|e| e.ty == "tf_mint").unwrap();
 
         let shares: UserBalanceResponse = wasm
             .query(
@@ -112,7 +288,7 @@ mod tests {
             .unwrap();
         assert!(!shares.balance.is_zero());
 
-        let _withdraw = wasm
+        let withdraw = wasm
             .execute(
                 contract_address.as_str(),
                 &ExecuteMsg::Redeem {
@@ -123,6 +299,7 @@ mod tests {
                 &alice,
             )
             .unwrap();
+        println!("{:?}", withdraw)
         // verify the correct execution
     }
 }

--- a/smart-contracts/contracts/cl-vault/src/test_tube/initialize.rs
+++ b/smart-contracts/contracts/cl-vault/src/test_tube/initialize.rs
@@ -171,7 +171,7 @@ pub mod initialize {
                 &instantiate_msg,
                 Some(admin.address().as_str()),
                 Some("cl-vault"),
-                sort_tokens(vec![coin(100000, pool.token0), coin(100000, pool.token1)]).as_ref(),
+                sort_tokens(vec![coin(5000, pool.token0), coin(507, pool.token1)]).as_ref(),
                 &admin,
             )
             .unwrap();

--- a/smart-contracts/contracts/cl-vault/src/vault/claim.rs
+++ b/smart-contracts/contracts/cl-vault/src/vault/claim.rs
@@ -7,14 +7,15 @@ pub fn execute_claim_user_rewards(
     recipient: &str,
 ) -> Result<Response, ContractError> {
     // addr unchecked is safe here because we will chekc addresses on save into this map
-    let mut user_rewards = match USER_REWARDS.may_load(deps.storage, Addr::unchecked(recipient))? {
-        Some(user_rewards) => user_rewards,
-        None => {
-            return Ok(Response::default()
-                .add_attribute("action", "claim_user_rewards")
-                .add_attribute("result", "no_rewards"))
-        }
-    };
+    let mut user_rewards =
+        match USER_REWARDS.may_load(deps.storage, deps.api.addr_validate(recipient)?)? {
+            Some(user_rewards) => user_rewards,
+            None => {
+                return Ok(Response::default()
+                    .add_attribute("action", "claim_user_rewards")
+                    .add_attribute("result", "no_rewards"))
+            }
+        };
 
     let send_rewards_msg = user_rewards.claim(recipient)?;
 

--- a/smart-contracts/contracts/cl-vault/src/vault/concentrated_liquidity.rs
+++ b/smart-contracts/contracts/cl-vault/src/vault/concentrated_liquidity.rs
@@ -66,7 +66,6 @@ pub fn withdraw_from_position(
 pub fn get_position(
     storage: &dyn Storage,
     querier: &QuerierWrapper,
-    _env: &Env,
 ) -> Result<FullPositionBreakdown, ContractError> {
     let position = POSITION.load(storage)?;
 

--- a/smart-contracts/contracts/cl-vault/src/vault/deposit.rs
+++ b/smart-contracts/contracts/cl-vault/src/vault/deposit.rs
@@ -370,7 +370,7 @@ mod tests {
         // the mint amount is dependent on the liquidity returned by MsgCreatePositionResponse, in this case 50% of current liquidty
         assert_eq!(
             SHARES.load(deps.as_ref().storage, sender).unwrap(),
-            Uint128::new(50)
+            Uint128::new(50000)
         );
         assert_eq!(
             response.messages[1],
@@ -378,7 +378,7 @@ mod tests {
                 sender: env.contract.address.to_string(),
                 amount: Some(OsmoCoin {
                     denom: "money".to_string(),
-                    amount: 50.to_string()
+                    amount: 50000.to_string()
                 }),
                 mint_to_address: env.contract.address.to_string()
             })

--- a/smart-contracts/contracts/cl-vault/src/vault/deposit.rs
+++ b/smart-contracts/contracts/cl-vault/src/vault/deposit.rs
@@ -14,8 +14,9 @@ use osmosis_std::types::{
 };
 
 use crate::{
+    debug,
     error::ContractResult,
-    helpers::{must_pay_one_or_two, sort_tokens},
+    helpers::{get_liquidity_amount_for_unused_funds, must_pay_one_or_two, sort_tokens},
     msg::{ExecuteMsg, MergePositionMsg},
     reply::Replies,
     state::{CurrentDeposit, CURRENT_DEPOSIT, POOL_CONFIG, POSITION, SHARES, VAULT_DENOM},
@@ -100,7 +101,7 @@ pub(crate) fn execute_exact_deposit(
 /// handles the reply to creating a position for a user deposit
 /// and calculates the refund for the user
 pub fn handle_deposit_create_position_reply(
-    deps: DepsMut,
+    mut deps: DepsMut,
     env: Env,
     data: SubMsgResult,
 ) -> ContractResult<Response> {
@@ -114,7 +115,7 @@ pub fn handle_deposit_create_position_reply(
         create_deposit_position_resp.liquidity_created.as_str(),
     )?);
 
-    let existing_position = get_position(deps.storage, &deps.querier, &env)?
+    let existing_position = get_position(deps.storage, &deps.querier)?
         .position
         .ok_or(ContractError::PositionNotFound)?;
 
@@ -129,21 +130,38 @@ pub fn handle_deposit_create_position_reply(
         .parse::<u128>()?
         .into();
 
+    let refunded = (
+        current_deposit.token0_in.checked_sub(Uint128::new(
+            create_deposit_position_resp.amount0.parse::<u128>()?,
+        ))?,
+        current_deposit.token1_in.checked_sub(Uint128::new(
+            create_deposit_position_resp.amount1.parse::<u128>()?,
+        ))?,
+    );
+
     // total_vault_shares.is_zero() should never be zero. This should ideally always enter the else and we are just sanity checking.
     let user_shares: Uint128 = if total_vault_shares.is_zero() {
         existing_liquidity.to_uint_floor().try_into()?
     } else {
+        let liquidity_amount_of_unused_funds: Decimal256 =
+            get_liquidity_amount_for_unused_funds(deps.branch(), &env, refunded)?;
+        let total_liquidity = existing_liquidity.checked_add(liquidity_amount_of_unused_funds)?;
+
+        debug!(
+            deps,
+            "liquidity_amount_of_unused_funds", liquidity_amount_of_unused_funds
+        );
+
+        // user_shares = total_vault_shares * user_liq / total_liq
         total_vault_shares
             .multiply_ratio(
                 user_created_liquidity.numerator(),
                 user_created_liquidity.denominator(),
             )
-            .multiply_ratio(
-                existing_liquidity.denominator(),
-                existing_liquidity.numerator(),
-            )
+            .multiply_ratio(total_liquidity.denominator(), total_liquidity.numerator())
             .try_into()?
     };
+    debug!(deps, "user_shares", user_shares);
 
     // TODO the locking of minted shares is a band-aid for giving out rewards to users,
     // once tokenfactory has send hooks, we can remove the lockup and have the users
@@ -204,6 +222,7 @@ pub fn handle_deposit_create_position_reply(
         attr("receiver", current_deposit.sender.as_str()),
     ];
 
+    // TODO, this remove causes borrower issues, see if we can remove the branch on line137
     // clear out the current deposit since it is no longer needed
     CURRENT_DEPOSIT.remove(deps.storage);
 
@@ -291,7 +310,8 @@ mod tests {
     };
 
     use crate::{
-        state::{PoolConfig, Position},
+        rewards::CoinList,
+        state::{PoolConfig, Position, STRATEGIST_REWARDS},
         test_helpers::QuasarQuerier,
     };
 
@@ -309,6 +329,9 @@ mod tests {
             .save(deps.as_mut().storage, &Position { position_id: 1 })
             .unwrap();
 
+        STRATEGIST_REWARDS
+            .save(deps.as_mut().storage, &CoinList::new())
+            .unwrap();
         CURRENT_DEPOSIT
             .save(
                 deps.as_mut().storage,

--- a/smart-contracts/contracts/cl-vault/src/vault/range.rs
+++ b/smart-contracts/contracts/cl-vault/src/vault/range.rs
@@ -90,7 +90,7 @@ pub fn execute_update_range_ticks(
     // todo: prevent re-entrancy by checking if we have anything in MODIFY_RANGE_STATE (redundant check but whatever)
 
     // this will error if we dont have a position anyway
-    let position_breakdown = get_position(deps.storage, &deps.querier, &env)?;
+    let position_breakdown = get_position(deps.storage, &deps.querier)?;
     let position = position_breakdown.position.unwrap();
 
     let withdraw_msg = MsgWithdrawPosition {
@@ -595,7 +595,10 @@ mod tests {
     #[test]
     fn test_handle_withdraw_position_reply_selects_correct_next_step_for_new_range() {
         let info = mock_info("addr0000", &[]);
-        let mut deps = mock_deps_with_querier_with_balance(&info, &[(MOCK_CONTRACT_ADDR, &[coin(1234, "token1")])]);
+        let mut deps = mock_deps_with_querier_with_balance(
+            &info,
+            &[(MOCK_CONTRACT_ADDR, &[coin(1234, "token1")])],
+        );
 
         STRATEGIST_REWARDS
             .save(
@@ -639,9 +642,14 @@ mod tests {
         assert_eq!(res.attributes[0].value, "swap_deposit_merge");
         assert_eq!(res.attributes[1].value, "swap");
         // check that our token1 attribute is incremented with the local balance - strategist rewards
-        assert_eq!(res.attributes.iter().find(|a| {
-            a.key == "token_in"
-        }).unwrap().value, "5962token1" );
+        assert_eq!(
+            res.attributes
+                .iter()
+                .find(|a| { a.key == "token_in" })
+                .unwrap()
+                .value,
+            "5962token1"
+        );
 
         // now test two-sided withdraw
         let data = SubMsgResult::Ok(SubMsgResponse {
@@ -661,8 +669,13 @@ mod tests {
         assert_eq!(res.messages.len(), 1);
         assert_eq!(res.attributes[0].value, "modify_range");
         assert_eq!(res.attributes[1].value, "create_position");
-        assert_eq!(res.attributes.iter().find(|a| {
-            a.key == "token1"
-        }).unwrap().value, "10734token1" ); // 10000 withdrawn + 1234 local balance - 500 rewards
+        assert_eq!(
+            res.attributes
+                .iter()
+                .find(|a| { a.key == "token1" })
+                .unwrap()
+                .value,
+            "10734token1"
+        ); // 10000 withdrawn + 1234 local balance - 500 rewards
     }
 }

--- a/smart-contracts/contracts/cl-vault/src/vault/range.rs
+++ b/smart-contracts/contracts/cl-vault/src/vault/range.rs
@@ -522,101 +522,21 @@ pub enum SwapDirection {
 
 #[cfg(test)]
 mod tests {
-    use std::{marker::PhantomData, str::FromStr};
+    use std::str::FromStr;
 
     use cosmwasm_std::{
         testing::{
-            mock_dependencies, mock_env, mock_info, MockApi, MockStorage, MOCK_CONTRACT_ADDR,
+            mock_dependencies, mock_env, mock_info
         },
-        Addr, Decimal, Empty, MessageInfo, OwnedDeps, SubMsgResponse, SubMsgResult,
+        Addr, Decimal, SubMsgResponse, SubMsgResult,
     };
-    use osmosis_std::types::{
-        cosmos::base::v1beta1::Coin as OsmoCoin,
-        osmosis::concentratedliquidity::v1beta1::{
-            FullPositionBreakdown, MsgWithdrawPositionResponse, Position as OsmoPosition,
-        },
-    };
+    use osmosis_std::types::osmosis::concentratedliquidity::v1beta1::MsgWithdrawPositionResponse;
 
     use crate::{
         state::{
-            PoolConfig, VaultConfig, MODIFY_RANGE_STATE, POOL_CONFIG, POSITION, RANGE_ADMIN,
-            VAULT_CONFIG,
-        },
-        test_helpers::QuasarQuerier,
+         MODIFY_RANGE_STATE, RANGE_ADMIN,
+        }, test_helpers::mock_deps_with_querier,
     };
-
-    fn mock_deps_with_querier(
-        info: &MessageInfo,
-    ) -> OwnedDeps<MockStorage, MockApi, QuasarQuerier, Empty> {
-        let mut deps = OwnedDeps {
-            storage: MockStorage::default(),
-            api: MockApi::default(),
-            querier: QuasarQuerier::new(
-                FullPositionBreakdown {
-                    position: Some(OsmoPosition {
-                        position_id: 1,
-                        address: MOCK_CONTRACT_ADDR.to_string(),
-                        pool_id: 1,
-                        lower_tick: 100,
-                        upper_tick: 1000,
-                        join_time: None,
-                        liquidity: "1000000.1".to_string(),
-                    }),
-                    asset0: Some(OsmoCoin {
-                        denom: "token0".to_string(),
-                        amount: "1000000".to_string(),
-                    }),
-                    asset1: Some(OsmoCoin {
-                        denom: "token1".to_string(),
-                        amount: "1000000".to_string(),
-                    }),
-                    claimable_spread_rewards: vec![
-                        OsmoCoin {
-                            denom: "token0".to_string(),
-                            amount: "100".to_string(),
-                        },
-                        OsmoCoin {
-                            denom: "token1".to_string(),
-                            amount: "100".to_string(),
-                        },
-                    ],
-                    claimable_incentives: vec![],
-                    forfeited_incentives: vec![],
-                },
-                500,
-            ),
-            custom_query_type: PhantomData,
-        };
-
-        let storage = &mut deps.storage;
-
-        RANGE_ADMIN.save(storage, &info.sender).unwrap();
-        POOL_CONFIG
-            .save(
-                storage,
-                &PoolConfig {
-                    pool_id: 1,
-                    token0: "token0".to_string(),
-                    token1: "token1".to_string(),
-                },
-            )
-            .unwrap();
-        VAULT_CONFIG
-            .save(
-                storage,
-                &VaultConfig {
-                    performance_fee: Decimal::zero(),
-                    treasury: Addr::unchecked("treasure"),
-                    swap_max_slippage: Decimal::from_ratio(1u128, 20u128),
-                },
-            )
-            .unwrap();
-        POSITION
-            .save(storage, &crate::state::Position { position_id: 1 })
-            .unwrap();
-
-        deps
-    }
 
     #[test]
     fn test_assert_range_admin() {

--- a/smart-contracts/contracts/cl-vault/src/vault/range.rs
+++ b/smart-contracts/contracts/cl-vault/src/vault/range.rs
@@ -525,17 +525,14 @@ mod tests {
     use std::str::FromStr;
 
     use cosmwasm_std::{
-        testing::{
-            mock_dependencies, mock_env, mock_info
-        },
+        testing::{mock_dependencies, mock_env, mock_info},
         Addr, Decimal, SubMsgResponse, SubMsgResult,
     };
     use osmosis_std::types::osmosis::concentratedliquidity::v1beta1::MsgWithdrawPositionResponse;
 
     use crate::{
-        state::{
-         MODIFY_RANGE_STATE, RANGE_ADMIN,
-        }, test_helpers::mock_deps_with_querier,
+        state::{MODIFY_RANGE_STATE, RANGE_ADMIN},
+        test_helpers::mock_deps_with_querier,
     };
 
     #[test]

--- a/smart-contracts/contracts/cl-vault/src/vault/withdraw.rs
+++ b/smart-contracts/contracts/cl-vault/src/vault/withdraw.rs
@@ -25,7 +25,7 @@ pub fn execute_withdraw(
     env: Env,
     info: MessageInfo,
     recipient: Option<String>,
-    amount: Uint128,
+    shares_to_withdraw: Uint128,
 ) -> Result<Response, ContractError> {
     let recipient = recipient.map_or(Ok(info.sender.clone()), |x| deps.api.addr_validate(&x))?;
 
@@ -37,7 +37,7 @@ pub fn execute_withdraw(
     // get the amount from SHARES state
     let user_shares = SHARES.load(deps.storage, info.sender.clone())?;
     let left_over = user_shares
-        .checked_sub(amount)
+        .checked_sub(shares_to_withdraw)
         .map_err(|_| ContractError::InsufficientFunds)?;
     SHARES.save(deps.storage, info.sender, &left_over)?;
 
@@ -54,14 +54,18 @@ pub fn execute_withdraw(
     let unused_balances = get_unused_balances(deps.storage, &deps.querier, &env)?;
     let dust0 = unused_balances.find_coin(pool_config.token0.clone()).amount;
     let dust1 = unused_balances.find_coin(pool_config.token1.clone()).amount;
-    let user_dust0 = dust0.checked_mul(amount)?.checked_div(total_shares)?;
-    let user_dust1 = dust1.checked_mul(amount)?.checked_div(total_shares)?;
+    let user_dust0 = dust0
+        .checked_mul(shares_to_withdraw)?
+        .checked_div(total_shares)?;
+    let user_dust1 = dust1
+        .checked_mul(shares_to_withdraw)?
+        .checked_div(total_shares)?;
     // save the new total amount of dust available for other actions
 
     CURRENT_WITHDRAWER_DUST.save(deps.storage, &(user_dust0, user_dust1))?;
 
     // burn the shares
-    let burn_coin = coin(amount.u128(), vault_denom);
+    let burn_coin = coin(shares_to_withdraw.u128(), vault_denom);
     let burn_msg: CosmosMsg = MsgBurn {
         sender: env.contract.address.clone().into_string(),
         amount: Some(burn_coin.into()),
@@ -72,13 +76,13 @@ pub fn execute_withdraw(
     CURRENT_WITHDRAWER.save(deps.storage, &recipient)?;
 
     // withdraw the user's funds from the position
-    let withdraw_msg = withdraw(deps, &env, amount)?; // TODOSN: Rename this function name to something more explicative
+    let withdraw_msg = withdraw(deps, &env, shares_to_withdraw)?; // TODOSN: Rename this function name to something more explicative
 
     Ok(Response::new()
         .add_attribute("method", "withdraw")
         .add_attribute("action", "withdraw")
         .add_attribute("liquidity_amount", withdraw_msg.liquidity_amount.as_str())
-        .add_attribute("share_amount", amount)
+        .add_attribute("share_amount", shares_to_withdraw)
         .add_message(burn_msg)
         .add_submessage(SubMsg::reply_on_success(
             withdraw_msg,
@@ -89,9 +93,9 @@ pub fn execute_withdraw(
 fn withdraw(
     deps: DepsMut,
     env: &Env,
-    shares: Uint128,
+    user_shares: Uint128,
 ) -> Result<MsgWithdrawPosition, ContractError> {
-    let existing_position = get_position(deps.storage, &deps.querier, env)?;
+    let existing_position = get_position(deps.storage, &deps.querier)?;
     let existing_liquidity: Decimal256 = existing_position
         .position
         .ok_or(ContractError::PositionNotFound)?
@@ -109,11 +113,11 @@ fn withdraw(
         .parse::<u128>()?
         .into();
 
-    let user_shares = Decimal256::from_ratio(shares, 1_u128)
+    let user_liquidity = Decimal256::from_ratio(user_shares, 1_u128)
         .checked_mul(existing_liquidity)?
         .checked_div(Decimal256::from_ratio(total_vault_shares, 1_u128))?;
 
-    withdraw_from_position(deps.storage, env, user_shares)
+    withdraw_from_position(deps.storage, env, user_liquidity)
 }
 
 pub fn handle_withdraw_user_reply(

--- a/smart-contracts/contracts/cl-vault/src/vault/withdraw.rs
+++ b/smart-contracts/contracts/cl-vault/src/vault/withdraw.rs
@@ -194,7 +194,7 @@ mod tests {
             CURRENT_WITHDRAWER_DUST.load(deps.as_ref().storage).unwrap(),
             (Uint128::new(20), Uint128::new(30))
         )
-      }
+    }
 
     // the execute withdraw flow should be easiest to test in test-tube, since it requires quite a bit of Osmsosis specific information
     // we just test the handle withdraw implementation here


### PR DESCRIPTION
## 1. Overview

This PR lets users also withdraw from the dust in the contract

## 2. Implementation details

Uses a dust state item to keep track of dust/ free funds
## 3. How to test/use

Tests are added as unit tests, all tests should still pass

## 4. Checklist

<!-- Checklist for PR author(s). -->

- [x ] Does the Readme need to be updated?

## 5. Limitations (optional)

This is dependent on the Dust being set in another PR
## 6. Future Work (optional)

<!-- Describe follow up work, if any. -->