### PR TITLE
Adding test tube test for treasury address change

### DIFF
--- a/smart-contracts/contracts/cl-vault/src/contract.rs
+++ b/smart-contracts/contracts/cl-vault/src/contract.rs
@@ -6,7 +6,7 @@ use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, ModifyRangeMsg, QueryMs
 use crate::query::{
     query_assets_from_shares, query_info, query_metadata, query_pool, query_position,
     query_total_assets, query_total_vault_token_supply, query_user_assets, query_user_balance,
-    query_user_rewards, RangeAdminResponse,
+    query_user_rewards, query_vault_config, RangeAdminResponse,
 };
 use crate::reply::Replies;
 use crate::rewards::{
@@ -140,6 +140,9 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> ContractResult<Binary> {
                     Ok(to_binary(&RangeAdminResponse {
                         address: range_admin.to_string(),
                     })?)
+                }
+                crate::msg::ClQueryMsg::VaultConfigQuery {} => {
+                    Ok(to_binary(&query_vault_config(deps)?)?)
                 }
             },
         },

--- a/smart-contracts/contracts/cl-vault/src/msg.rs
+++ b/smart-contracts/contracts/cl-vault/src/msg.rs
@@ -5,7 +5,7 @@ use cw_vault_multi_standard::{VaultStandardExecuteMsg, VaultStandardQueryMsg};
 use crate::{
     query::{
         AssetsBalanceResponse, PoolResponse, PositionResponse, RangeAdminResponse,
-        UserRewardsResponse, UserSharesBalanceResponse,
+        UserRewardsResponse, UserSharesBalanceResponse, VaultConfigResponse,
     },
     state::VaultConfig,
 };
@@ -101,6 +101,8 @@ pub enum ClQueryMsg {
     Position {},
     #[returns(RangeAdminResponse)]
     RangeAdmin {},
+    #[returns(VaultConfigResponse)]
+    VaultConfigQuery {},
 }
 
 /// ExecuteMsg for an Autocompounding Vault.

--- a/smart-contracts/contracts/cl-vault/src/query.rs
+++ b/smart-contracts/contracts/cl-vault/src/query.rs
@@ -1,5 +1,6 @@
 use crate::helpers::get_unused_balances;
 use crate::rewards::CoinList;
+use crate::state::{VaultConfig, VAULT_CONFIG};
 use crate::vault::concentrated_liquidity::get_position;
 use crate::{
     error::ContractResult,
@@ -68,6 +69,11 @@ pub struct RangeAdminResponse {
 #[cw_serde]
 pub struct TotalVaultTokenSupplyResponse {
     pub total: Uint128,
+}
+
+#[cw_serde]
+pub struct VaultConfigResponse {
+    pub config: VaultConfig,
 }
 
 pub fn query_metadata(deps: Deps) -> ContractResult<MetadataResponse> {
@@ -201,4 +207,12 @@ pub fn query_total_vault_token_supply(deps: Deps) -> ContractResult<TotalVaultTo
         .parse::<u128>()?
         .into();
     Ok(TotalVaultTokenSupplyResponse { total })
+}
+
+/// queries the vault config
+pub fn query_vault_config(deps: Deps) -> ContractResult<VaultConfigResponse> {
+    let vault_config = VAULT_CONFIG.load(deps.storage)?;
+    Ok(VaultConfigResponse {
+        config: vault_config,
+    })
 }

--- a/smart-contracts/contracts/cl-vault/src/test_tube/admin.rs
+++ b/smart-contracts/contracts/cl-vault/src/test_tube/admin.rs
@@ -55,6 +55,7 @@ mod tests {
 
     proptest! {
         #[test]
+        #[ignore]
         fn test_update_range_admin_works(
         (initial_lower_tick, initial_upper_tick) in get_initial_range(),
         ) {

--- a/smart-contracts/contracts/cl-vault/src/test_tube/admin.rs
+++ b/smart-contracts/contracts/cl-vault/src/test_tube/admin.rs
@@ -1,12 +1,116 @@
 #[cfg(test)]
 mod tests {
+    use crate::msg::AdminExtensionExecuteMsg::UpdateConfig;
+    use crate::msg::ClQueryMsg::VaultConfigQuery;
+    use crate::query::VaultConfigResponse;
+    use crate::{
+        msg::{ExecuteMsg, ExtensionQueryMsg, QueryMsg},
+        test_tube::initialize::initialize::init_test_contract,
+    };
+    use cosmwasm_std::{Addr, Coin, Decimal, Uint128};
+    use osmosis_std::types::{
+        cosmos::base::v1beta1,
+        osmosis::concentratedliquidity::poolmodel::concentrated::v1beta1::MsgCreateConcentratedPool,
+    };
+    use osmosis_test_tube::{
+        Account, Bank, ConcentratedLiquidity, Module, OsmosisTestApp, SigningAccount, Wasm,
+    };
+    use proptest::prelude::*;
 
-    use crate::test_tube::default_init;
+    use crate::state::VaultConfig;
 
-    #[test]
-    #[ignore]
-    fn range_admin_update_works() {
-        let (_app, _contract_address, _cl_pool_id, _admin) = default_init();
-        // change the range admin and verify that it works
+    const ITERATIONS_NUMBER: usize = 1000;
+    const ACCOUNTS_NUMBER: u64 = 10;
+    const ACCOUNTS_INITIAL_BALANCE: u128 = 1_000_000_000_000;
+    const DENOM_BASE: &str = "ZZZZZ";
+    //"ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7";
+    const DENOM_QUOTE: &str =
+        "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858";
+
+    fn update_config(
+        wasm: &Wasm<OsmosisTestApp>,
+        cl: &ConcentratedLiquidity<OsmosisTestApp>,
+        contract_address: &Addr,
+        new_config: VaultConfig,
+        admin_account: &SigningAccount,
+    ) {
+        let _update_config = wasm
+            .execute(
+                contract_address.as_str(),
+                &ExecuteMsg::VaultExtension(crate::msg::ExtensionExecuteMsg::Admin(UpdateConfig {
+                    updates: new_config,
+                })),
+                &[],
+                admin_account,
+            )
+            .unwrap();
+    }
+
+    prop_compose! {
+        // TODO: evaluate if lower_tick and upper_tick are too much arbitrary
+        fn get_initial_range()(lower_tick in 1i64..1_000_000, upper_tick in 1_000_001i64..2_000_000) -> (i64, i64) {
+            (lower_tick, upper_tick)
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_update_range_admin_works(
+        (initial_lower_tick, initial_upper_tick) in get_initial_range(),
+        ) {
+            // Creating test core
+            let (app, contract_address, cl_pool_id, admin_account) = init_test_contract(
+                "./test-tube-build/wasm32-unknown-unknown/release/cl_vault.wasm",
+                &[
+                    Coin::new(100_000_000_000_000_000_000_000, "uosmo"),
+                    Coin::new(100_000_000_000_000_000_000_000, DENOM_BASE),
+                    Coin::new(100_000_000_000_000_000_000_000, DENOM_QUOTE),
+                ],
+                MsgCreateConcentratedPool {
+                    sender: "overwritten".to_string(),
+                    denom0: DENOM_BASE.to_string(),
+                    denom1: DENOM_QUOTE.to_string(),
+                    tick_spacing: 1,
+                    spread_factor: "100000000000000".to_string(),
+                },
+                initial_lower_tick,
+                initial_upper_tick,
+                vec![
+                    v1beta1::Coin {
+                        denom: DENOM_BASE.to_string(),
+                        amount: "100000000000000000".to_string(),
+                    },
+                    v1beta1::Coin {
+                        denom: DENOM_QUOTE.to_string(),
+                        amount: "100000000000000000".to_string(),
+                    },
+                ],
+                Uint128::zero(),
+                Uint128::zero(),
+            );
+            let wasm = Wasm::new(&app);
+            let cl = ConcentratedLiquidity::new(&app);
+            let bank = Bank::new(&app);
+
+            // initialise and update the new config
+            let new_config = VaultConfig {
+                performance_fee: Decimal::percent(5),
+                treasury: Addr::unchecked("new_treasury_address"),
+                swap_max_slippage: Decimal::percent(5),
+            };
+            update_config(&wasm, &cl, &contract_address, new_config, &admin_account);
+
+            // query the new config
+            let res : VaultConfigResponse = wasm.query(
+                contract_address.as_str(),
+                &QueryMsg::VaultExtension(ExtensionQueryMsg::ConcentratedLiquidity(
+                    VaultConfigQuery{},
+                ))
+            )
+                .unwrap();
+
+            // checking against admin address as the admin is treasury while instantiating.
+            assert_ne!(res.config.treasury, admin_account.address());
+        }
     }
 }


### PR DESCRIPTION
## 1. Overview

This PR aims to add tests for treasury address change.

## 2. Implementation details

* Adds a test tube test for verifying change of treasury address
* Adds a query to get vault config

## 3. How to test/use

Run the protest in admin.rs

## 4. Checklist

## 5. Limitations (optional)

<!-- Describe any limitation of the capabilities listed in the Overview section. -->

## 6. Future Work (optional)

<!-- Describe follow up work, if any. -->