### PR TITLE
Fix/init mint amount ref tick exp cache

### DIFF
--- a/smart-contracts/contracts/cl-vault/.cargo/config
+++ b/smart-contracts/contracts/cl-vault/.cargo/config
@@ -2,5 +2,5 @@
 wasm = "build --release --lib --target wasm32-unknown-unknown"
 unit-test = "test --lib"
 schema = "run --bin schema"
-test-tube = "test --package cl-vault --lib -- --include-ignored test_tube:: --nocapture"
+test-tube = "test --package cl-vault --lib -- --include-ignored test_tube:: --nocapture --test-threads=1"
 test-tube-build = "build --release --lib --target  wasm32-unknown-unknown --target-dir ./test-tube-build"

--- a/smart-contracts/contracts/cl-vault/src/contract.rs
+++ b/smart-contracts/contracts/cl-vault/src/contract.rs
@@ -98,9 +98,6 @@ pub fn execute(
                 crate::msg::ExtensionExecuteMsg::ClaimRewards {} => {
                     execute_claim_user_rewards(deps, info.sender.as_str())
                 }
-                crate::msg::ExtensionExecuteMsg::PurgeTickExpCache {} => {
-                    purge_tick_exp_cache(deps.storage) // TODO: Move this to another domain if we implement it
-                }
             }
         }
     }

--- a/smart-contracts/contracts/cl-vault/src/contract.rs
+++ b/smart-contracts/contracts/cl-vault/src/contract.rs
@@ -2,6 +2,7 @@ use crate::error::{ContractError, ContractResult};
 use crate::instantiate::{
     handle_create_denom_reply, handle_instantiate, handle_instantiate_create_position_reply,
 };
+use crate::math::tick::purge_tick_exp_cache;
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, ModifyRangeMsg, QueryMsg};
 use crate::query::{
     query_assets_from_shares, query_info, query_metadata, query_pool, query_position,
@@ -96,6 +97,9 @@ pub fn execute(
                 }
                 crate::msg::ExtensionExecuteMsg::ClaimRewards {} => {
                     execute_claim_user_rewards(deps, info.sender.as_str())
+                }
+                crate::msg::ExtensionExecuteMsg::PurgeTickExpCache {} => {
+                    purge_tick_exp_cache(deps.storage) // TODO: Move this to another domain if we implement it
                 }
             }
         }

--- a/smart-contracts/contracts/cl-vault/src/error.rs
+++ b/smart-contracts/contracts/cl-vault/src/error.rs
@@ -121,6 +121,9 @@ pub enum ContractError {
     #[error("Invalid current tick and deposit token combination")]
     InvalidCurrentTick {},
 
+    #[error("Tick not found in tick cache, tick: {tick}")]
+    TickNotFound {tick: i64},
+
     #[error("Tick corresponding to price not found in cache even after rebuilding")]
     TickNotFoundAfterRebuild {},
 }

--- a/smart-contracts/contracts/cl-vault/src/error.rs
+++ b/smart-contracts/contracts/cl-vault/src/error.rs
@@ -122,7 +122,7 @@ pub enum ContractError {
     InvalidCurrentTick {},
 
     #[error("Tick not found in tick cache, tick: {tick}")]
-    TickNotFound {tick: i64},
+    TickNotFound { tick: i64 },
 
     #[error("Tick corresponding to price not found in cache even after rebuilding")]
     TickNotFoundAfterRebuild {},

--- a/smart-contracts/contracts/cl-vault/src/error.rs
+++ b/smart-contracts/contracts/cl-vault/src/error.rs
@@ -120,4 +120,7 @@ pub enum ContractError {
 
     #[error("Invalid current tick and deposit token combination")]
     InvalidCurrentTick {},
+
+    #[error("Tick corresponding to price not found in cache even after rebuilding")]
+    TickNotFoundAfterRebuild {},
 }

--- a/smart-contracts/contracts/cl-vault/src/instantiate.rs
+++ b/smart-contracts/contracts/cl-vault/src/instantiate.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
     coin, CosmosMsg, Decimal, DepsMut, Env, MessageInfo, Response, StdError, SubMsg, SubMsgResult,
-    Uint128,
+    Uint128, Deps,
 };
 use osmosis_std::types::osmosis::concentratedliquidity::v1beta1::{
     MsgCreatePositionResponse, Pool,
@@ -11,13 +11,13 @@ use osmosis_std::types::osmosis::tokenfactory::v1beta1::{
 };
 
 use crate::helpers::must_pay_one_or_two;
-use crate::math::tick::build_tick_exp_cache;
+use crate::math::tick::{build_tick_exp_cache, verify_tick_exp_cache};
 use crate::msg::InstantiateMsg;
 use crate::reply::Replies;
 use crate::rewards::CoinList;
 use crate::state::{
     Metadata, PoolConfig, Position, ADMIN_ADDRESS, METADATA, POOL_CONFIG, POSITION, RANGE_ADMIN,
-    STRATEGIST_REWARDS, VAULT_CONFIG, VAULT_DENOM,
+    STRATEGIST_REWARDS, VAULT_CONFIG, VAULT_DENOM, TICK_EXP_CACHE,
 };
 use crate::vault::concentrated_liquidity::create_position;
 use crate::ContractError;
@@ -36,6 +36,7 @@ pub fn handle_instantiate(
     }
 
     build_tick_exp_cache(deps.storage)?;
+    verify_tick_exp_cache(deps.storage)?;
 
     VAULT_CONFIG.save(deps.storage, &msg.config)?;
 

--- a/smart-contracts/contracts/cl-vault/src/instantiate.rs
+++ b/smart-contracts/contracts/cl-vault/src/instantiate.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
     coin, CosmosMsg, Decimal, DepsMut, Env, MessageInfo, Response, StdError, SubMsg, SubMsgResult,
-    Uint128, Deps,
+    Uint128,
 };
 use osmosis_std::types::osmosis::concentratedliquidity::v1beta1::{
     MsgCreatePositionResponse, Pool,
@@ -17,7 +17,7 @@ use crate::reply::Replies;
 use crate::rewards::CoinList;
 use crate::state::{
     Metadata, PoolConfig, Position, ADMIN_ADDRESS, METADATA, POOL_CONFIG, POSITION, RANGE_ADMIN,
-    STRATEGIST_REWARDS, VAULT_CONFIG, VAULT_DENOM, TICK_EXP_CACHE,
+    STRATEGIST_REWARDS, VAULT_CONFIG, VAULT_DENOM,
 };
 use crate::vault::concentrated_liquidity::create_position;
 use crate::ContractError;

--- a/smart-contracts/contracts/cl-vault/src/math/tick.rs
+++ b/smart-contracts/contracts/cl-vault/src/math/tick.rs
@@ -93,7 +93,7 @@ pub fn price_to_tick(storage: &mut dyn Storage, price: Decimal256) -> Result<i12
     let mut geo_spacing;
     let mut has_rebuilt_cache = false; // Flag to track if cache has been rebuilt
 
-    if price > Decimal256::one() {
+    if price >= Decimal256::one() {
         let mut index = 0i64;
         loop {
             match TICK_EXP_CACHE.may_load(storage, index)? {

--- a/smart-contracts/contracts/cl-vault/src/math/tick.rs
+++ b/smart-contracts/contracts/cl-vault/src/math/tick.rs
@@ -186,11 +186,9 @@ fn pow_ten_internal_dec_256(exponent: i64) -> Result<Decimal256, ContractError> 
     }
 }
 
-// TODO: Move this entrypoint to another place like execute.rs
 // Iterate over the TICK_EXP_CACHE map and remove each entry to purge the cached entries
+// This method is only used by tests
 pub fn purge_tick_exp_cache(storage: &mut dyn Storage) -> Result<Response, ContractError> {
-    // TODO: -> assert_admin(deps, caller); if we leave this exposed
-
     let keys: Vec<i64> = TICK_EXP_CACHE
         .range(storage, None, None, cosmwasm_std::Order::Ascending)
         .map(|item| item.unwrap().0)

--- a/smart-contracts/contracts/cl-vault/src/math/tick.rs
+++ b/smart-contracts/contracts/cl-vault/src/math/tick.rs
@@ -186,21 +186,6 @@ fn pow_ten_internal_dec_256(exponent: i64) -> Result<Decimal256, ContractError> 
     }
 }
 
-// Iterate over the TICK_EXP_CACHE map and remove each entry to purge the cached entries
-// This method is only used by tests
-pub fn purge_tick_exp_cache(storage: &mut dyn Storage) -> Result<Response, ContractError> {
-    let keys: Vec<i64> = TICK_EXP_CACHE
-        .range(storage, None, None, cosmwasm_std::Order::Ascending)
-        .map(|item| item.unwrap().0)
-        .collect();
-
-    for key in keys {
-        TICK_EXP_CACHE.remove(storage, key);
-    }
-
-    Ok(Response::default())
-}
-
 pub fn build_tick_exp_cache(storage: &mut dyn Storage) -> Result<(), ContractError> {
     // Build positive indices
     let mut max_price = Decimal256::one();

--- a/smart-contracts/contracts/cl-vault/src/math/tick.rs
+++ b/smart-contracts/contracts/cl-vault/src/math/tick.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use cosmwasm_std::{Decimal, Decimal256, Response, Storage, Uint128, Deps};
+use cosmwasm_std::{Decimal, Decimal256, Response, Storage, Uint128};
 
 use crate::{
     state::{TickExpIndexData, TICK_EXP_CACHE},
@@ -255,7 +255,6 @@ pub fn build_tick_exp_cache(storage: &mut dyn Storage) -> Result<(), ContractErr
     Ok(())
 }
 
-
 pub fn verify_tick_exp_cache(storage: &dyn Storage) -> Result<(), ContractError> {
     // iterate over the tick_exp_cache in both directions.
     // until we reach MAX or MIN price, we should have a cache hit at each increasing or decreasing index
@@ -265,7 +264,9 @@ pub fn verify_tick_exp_cache(storage: &dyn Storage) -> Result<(), ContractError>
 
     while max_price < max_spot_price {
         let tick_exp_index_data = TICK_EXP_CACHE.load(storage, positive_index).map_err(|_| {
-            ContractError::TickNotFound{ tick: positive_index }
+            ContractError::TickNotFound {
+                tick: positive_index,
+            }
         })?;
 
         max_price = tick_exp_index_data.max_price;
@@ -279,7 +280,9 @@ pub fn verify_tick_exp_cache(storage: &dyn Storage) -> Result<(), ContractError>
 
     while min_price > min_spot_price {
         let tick_exp_index_data = TICK_EXP_CACHE.load(storage, negative_index).map_err(|_| {
-            ContractError::TickNotFound{ tick: negative_index }
+            ContractError::TickNotFound {
+                tick: negative_index,
+            }
         })?;
 
         min_price = tick_exp_index_data.initial_price;
@@ -316,12 +319,16 @@ mod tests {
         let mut deps = mock_dependencies();
         build_tick_exp_cache(deps.as_mut().storage).unwrap();
 
-        let tick = TICK_EXP_CACHE.range(deps.as_ref().storage, None, None, Order::Ascending).last().unwrap().unwrap().0;
+        let tick = TICK_EXP_CACHE
+            .range(deps.as_ref().storage, None, None, Order::Ascending)
+            .last()
+            .unwrap()
+            .unwrap()
+            .0;
 
         TICK_EXP_CACHE.remove(deps.as_mut().storage, tick);
         let err = verify_tick_exp_cache(deps.as_ref().storage).unwrap_err();
         assert_eq!(err, ContractError::TickNotFound { tick })
-
     }
 
     #[test]
@@ -329,12 +336,16 @@ mod tests {
         let mut deps = mock_dependencies();
         build_tick_exp_cache(deps.as_mut().storage).unwrap();
 
-        let tick = TICK_EXP_CACHE.range(deps.as_ref().storage, None, None, Order::Descending).last().unwrap().unwrap().0;
+        let tick = TICK_EXP_CACHE
+            .range(deps.as_ref().storage, None, None, Order::Descending)
+            .last()
+            .unwrap()
+            .unwrap()
+            .0;
 
         TICK_EXP_CACHE.remove(deps.as_mut().storage, tick);
         let err = verify_tick_exp_cache(deps.as_ref().storage).unwrap_err();
         assert_eq!(err, ContractError::TickNotFound { tick })
-
     }
 
     #[test]

--- a/smart-contracts/contracts/cl-vault/src/math/tick.rs
+++ b/smart-contracts/contracts/cl-vault/src/math/tick.rs
@@ -307,7 +307,8 @@ mod tests {
         build_tick_exp_cache(deps.as_mut().storage).unwrap();
 
         TICK_EXP_CACHE.remove(deps.as_mut().storage, 5);
-        verify_tick_exp_cache(deps.as_ref().storage).unwrap_err();
+        let err = verify_tick_exp_cache(deps.as_ref().storage).unwrap_err();
+        assert_eq!(err, ContractError::TickNotFound { tick: 5 })
     }
 
     #[test]
@@ -318,7 +319,9 @@ mod tests {
         let tick = TICK_EXP_CACHE.range(deps.as_ref().storage, None, None, Order::Ascending).last().unwrap().unwrap().0;
 
         TICK_EXP_CACHE.remove(deps.as_mut().storage, tick);
-        verify_tick_exp_cache(deps.as_ref().storage).unwrap_err();
+        let err = verify_tick_exp_cache(deps.as_ref().storage).unwrap_err();
+        assert_eq!(err, ContractError::TickNotFound { tick })
+
     }
 
     #[test]
@@ -329,7 +332,9 @@ mod tests {
         let tick = TICK_EXP_CACHE.range(deps.as_ref().storage, None, None, Order::Descending).last().unwrap().unwrap().0;
 
         TICK_EXP_CACHE.remove(deps.as_mut().storage, tick);
-        verify_tick_exp_cache(deps.as_ref().storage).unwrap_err();
+        let err = verify_tick_exp_cache(deps.as_ref().storage).unwrap_err();
+        assert_eq!(err, ContractError::TickNotFound { tick })
+
     }
 
     #[test]
@@ -338,7 +343,8 @@ mod tests {
         build_tick_exp_cache(deps.as_mut().storage).unwrap();
 
         TICK_EXP_CACHE.remove(deps.as_mut().storage, -5);
-        verify_tick_exp_cache(deps.as_ref().storage).unwrap_err();
+        let err = verify_tick_exp_cache(deps.as_ref().storage).unwrap_err();
+        assert_eq!(err, ContractError::TickNotFound { tick: -5 })
     }
 
     #[test]

--- a/smart-contracts/contracts/cl-vault/src/math/tick.rs
+++ b/smart-contracts/contracts/cl-vault/src/math/tick.rs
@@ -264,7 +264,9 @@ pub fn verify_tick_exp_cache(storage: &dyn Storage) -> Result<(), ContractError>
     let max_spot_price = Decimal256::from_str(MAX_SPOT_PRICE)?;
 
     while max_price < max_spot_price {
-        let tick_exp_index_data = TICK_EXP_CACHE.load(storage, positive_index)?;
+        let tick_exp_index_data = TICK_EXP_CACHE.load(storage, positive_index).map_err(|_| {
+            ContractError::TickNotFound{ tick: positive_index }
+        })?;
 
         max_price = tick_exp_index_data.max_price;
         positive_index += 1;
@@ -276,7 +278,9 @@ pub fn verify_tick_exp_cache(storage: &dyn Storage) -> Result<(), ContractError>
     let min_spot_price = Decimal256::from_str(MIN_SPOT_PRICE)?;
 
     while min_price > min_spot_price {
-        let tick_exp_index_data = TICK_EXP_CACHE.load(storage, negative_index)?;
+        let tick_exp_index_data = TICK_EXP_CACHE.load(storage, negative_index).map_err(|_| {
+            ContractError::TickNotFound{ tick: negative_index }
+        })?;
 
         min_price = tick_exp_index_data.initial_price;
         negative_index -= 1;

--- a/smart-contracts/contracts/cl-vault/src/msg.rs
+++ b/smart-contracts/contracts/cl-vault/src/msg.rs
@@ -24,6 +24,8 @@ pub enum ExtensionExecuteMsg {
     DistributeRewards {},
     /// Claim rewards belonging to a single user
     ClaimRewards {},
+    /// Purge cache tick
+    PurgeTickExpCache(), // TODO: Evaluate if needed, if not adjust test_tube test in range.rs
 }
 
 /// Apollo extension messages define functionality that is part of all apollo

--- a/smart-contracts/contracts/cl-vault/src/msg.rs
+++ b/smart-contracts/contracts/cl-vault/src/msg.rs
@@ -24,8 +24,6 @@ pub enum ExtensionExecuteMsg {
     DistributeRewards {},
     /// Claim rewards belonging to a single user
     ClaimRewards {},
-    /// Purge cache tick
-    PurgeTickExpCache(), // TODO: Evaluate if needed, if not adjust test_tube test in range.rs
 }
 
 /// Apollo extension messages define functionality that is part of all apollo

--- a/smart-contracts/contracts/cl-vault/src/test_tube/initialize.rs
+++ b/smart-contracts/contracts/cl-vault/src/test_tube/initialize.rs
@@ -9,7 +9,7 @@ pub mod initialize {
         CreateConcentratedLiquidityPoolsProposal, Pool, PoolRecord, PoolsRequest,
     };
     use osmosis_std::types::osmosis::poolmanager::v1beta1::{
-        MsgSwapExactAmountIn, SwapAmountInRoute,
+        MsgSwapExactAmountIn, SpotPriceRequest, SwapAmountInRoute,
     };
     use osmosis_std::types::osmosis::tokenfactory::v1beta1::QueryDenomsFromCreatorRequest;
     use osmosis_test_tube::{
@@ -76,13 +76,12 @@ pub mod initialize {
     ) -> (OsmosisTestApp, Addr, u64, SigningAccount) {
         // Create new osmosis appchain instance
         let app = OsmosisTestApp::new();
+        let pm = PoolManager::new(&app);
+        let cl = ConcentratedLiquidity::new(&app);
+        let wasm = Wasm::new(&app);
 
         // Create new account with initial funds
         let admin = app.init_account(admin_balance).unwrap();
-
-        // `Wasm` is the module we use to interact with cosmwasm releated logic on the appchain
-        // it implements `Module` trait which you will see more later.
-        let wasm = Wasm::new(&app);
 
         // Load compiled wasm bytecode
         let wasm_byte_code = std::fs::read(filename).unwrap();
@@ -93,7 +92,6 @@ pub mod initialize {
             .code_id;
 
         // Setup a dummy CL pool to work with
-        let cl = ConcentratedLiquidity::new(&app);
         let gov = GovWithAppAccess::new(&app);
         gov.propose_and_execute(
             CreateConcentratedLiquidityPoolsProposal::TYPE_URL.to_string(),
@@ -127,7 +125,7 @@ pub mod initialize {
                 sender: admin.address(),
                 lower_tick,
                 upper_tick,
-                tokens_provided,
+                tokens_provided: tokens_provided.clone(),
                 token_min_amount0: token_min_amount0.to_string(),
                 token_min_amount1: token_min_amount1.to_string(),
             },
@@ -135,10 +133,20 @@ pub mod initialize {
         )
         .unwrap();
 
+        // Get and assert spot price is 1.0
+        let spot_price = pm
+            .query_spot_price(&SpotPriceRequest {
+                base_asset_denom: tokens_provided[0].denom.to_string(),
+                quote_asset_denom: tokens_provided[1].denom.to_string(),
+                pool_id: pool.id,
+            })
+            .unwrap();
+        assert_eq!(spot_price.spot_price, "1.000000000000000000");
+
         // Increment the app time for twaps to function, this is needed to do not fail on querying a twap for a timeframe higher than the chain existence
         app.increase_time(1000000);
 
-        // Instantiate
+        // Instantiate vault
         let contract = wasm
             .instantiate(
                 code_id,
@@ -209,8 +217,8 @@ pub mod initialize {
         // Create Alice account
         let alice = app
             .init_account(&[
-                Coin::new(1_000_000_000_000, "uatom"),
-                Coin::new(1_000_000_000_000, "uosmo"),
+                Coin::new(1_000_000_000_000, DENOM_BASE),
+                Coin::new(1_000_000_000_000, DENOM_QUOTE),
             ])
             .unwrap();
 
@@ -220,10 +228,10 @@ pub mod initialize {
                 sender: alice.address(),
                 routes: vec![SwapAmountInRoute {
                     pool_id: cl_pool_id,
-                    token_out_denom: "uatom".to_string(),
+                    token_out_denom: DENOM_BASE.to_string(),
                 }],
                 token_in: Some(v1beta1::Coin {
-                    denom: "uosmo".to_string(),
+                    denom: DENOM_QUOTE.to_string(),
                     amount: "1000".to_string(),
                 }),
                 token_out_min_amount: "1".to_string(),

--- a/smart-contracts/contracts/cl-vault/src/test_tube/initialize.rs
+++ b/smart-contracts/contracts/cl-vault/src/test_tube/initialize.rs
@@ -250,7 +250,7 @@ pub mod initialize {
                 ModifyRangeMsg {
                     lower_price: Decimal::from_str("0.993").unwrap(),
                     upper_price: Decimal::from_str("1.002").unwrap(),
-                    max_slippage: Decimal::permille(5),
+                    max_slippage: Decimal::bps(9500),
                     ratio_of_swappable_funds_to_use: Decimal::one(),
                     twap_window_seconds: 45,
                 },

--- a/smart-contracts/contracts/cl-vault/src/test_tube/proptest.rs
+++ b/smart-contracts/contracts/cl-vault/src/test_tube/proptest.rs
@@ -464,7 +464,7 @@ mod tests {
     // get_initial_range generates random lower and upper ticks for the initial position
     prop_compose! {
         // TODO: evaluate if lower_tick and upper_tick are too much arbitrary
-        fn get_initial_range()(lower_tick in -500_000i64..0, upper_tick in 1i64..50_000) -> (i64, i64) {
+        fn get_initial_range()(lower_tick in -300_000i64..0, upper_tick in 1i64..500_000) -> (i64, i64) {
             (lower_tick, upper_tick)
         }
     }

--- a/smart-contracts/contracts/cl-vault/src/test_tube/proptest.rs
+++ b/smart-contracts/contracts/cl-vault/src/test_tube/proptest.rs
@@ -428,37 +428,6 @@ mod tests {
         numeric_part.parse::<u128>().unwrap()
     }
 
-    // ASSERT METHODS
-
-    // TODO: REMOVE THIS DEPRECATED
-    /*fn assert_deposit_withdraw(
-        wasm: &Wasm<OsmosisTestApp>,
-        contract_address: &Addr,
-        accounts: &Vec<SigningAccount>,
-        accounts_shares_balance: HashMap<String, Uint128>,
-    ) {
-        // TODO: multi-query foreach user created previously
-        for account in accounts {
-            let shares = get_user_shares_balance(wasm, contract_address, account);
-
-            // Check that the current account iterated shares balance is the same we expect from Hashmap
-            assert_eq!(
-                shares.balance,
-                accounts_shares_balance.get(&account.address()).unwrap()
-            );
-        }
-    }*/
-
-    /*
-    fn assert_swap() {
-        todo!()
-    }
-
-    fn assert_update_range() {
-        todo!()
-    }
-    */
-
     // COMPOSE STRATEGY
 
     // get_initial_range generates random lower and upper ticks for the initial position
@@ -569,19 +538,15 @@ mod tests {
                 match actions[i] {
                     Action::Deposit => {
                         deposit(&wasm, &bank, &contract_address, &accounts[account_indexes[i] as usize], percentages[i], DENOM_BASE, DENOM_QUOTE);
-                        //assert_deposit_withdraw(&wasm, &contract_address, &accounts);
                     },
                     Action::Withdraw => {
                         withdraw(&wasm, &contract_address, &accounts[account_indexes[i] as usize], percentages[i]);
-                        //assert_deposit_withdraw(&wasm, &contract_address, &accounts);
                     },
                     // Action::Swap => {
                     //     swap(&wasm, &bank, &contract_address, &accounts[account_indexes[i] as usize], percentages[i], cl_pool_id);
-                    //     assert_swap(); // todo!()
                     // },
                     Action::UpdateRange => {
                         update_range(&wasm, &cl, &contract_address, percentages[i], &admin_account);
-                        //assert_update_range(); // todo!()
                     },
                 }
             }

--- a/smart-contracts/contracts/cl-vault/src/test_tube/proptest.rs
+++ b/smart-contracts/contracts/cl-vault/src/test_tube/proptest.rs
@@ -27,9 +27,9 @@ mod tests {
     const ITERATIONS_NUMBER: usize = 1000;
     const ACCOUNTS_NUMBER: u64 = 10;
     const ACCOUNTS_INITIAL_BALANCE: u128 = 100_000_000_000_000_000;
-    const DENOM_BASE: &str = "ZZZZZ"; //"ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7";
+    const DENOM_BASE: &str = "ZZZZZ";
     const DENOM_QUOTE: &str =
-        "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"; //"ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2";
+        "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858";
 
     #[derive(Clone, Copy, Debug)]
     enum Action {
@@ -498,7 +498,7 @@ mod tests {
 
     fn get_cases() -> u32 {
         std::env::var("PROPTEST_CASES")
-            .unwrap_or("256".to_string())
+            .unwrap_or("100".to_string())
             .parse()
             .unwrap()
     }

--- a/smart-contracts/contracts/cl-vault/src/test_tube/range.rs
+++ b/smart-contracts/contracts/cl-vault/src/test_tube/range.rs
@@ -35,8 +35,8 @@ mod test {
             // TODO: Evaluate creating a default_init() variant i.e. out_of_range_init()
             "./test-tube-build/wasm32-unknown-unknown/release/cl_vault.wasm",
             &[
-                Coin::new(1_000_000_000_000, DENOM_BASE),
-                Coin::new(1_000_000_000_000, DENOM_QUOTE),
+                Coin::new(ADMIN_BALANCE_AMOUNT, DENOM_BASE),
+                Coin::new(ADMIN_BALANCE_AMOUNT, DENOM_QUOTE),
             ],
             MsgCreateConcentratedPool {
                 sender: "overwritten".to_string(),
@@ -50,11 +50,11 @@ mod test {
             vec![
                 v1beta1::Coin {
                     denom: DENOM_BASE.to_string(),
-                    amount: "10000000000".to_string(),
+                    amount: TOKENS_PROVIDED_AMOUNT.to_string(),
                 },
                 v1beta1::Coin {
                     denom: DENOM_QUOTE.to_string(),
-                    amount: "10000000000".to_string(),
+                    amount: TOKENS_PROVIDED_AMOUNT.to_string(),
                 },
             ],
             Uint128::zero(),
@@ -74,11 +74,11 @@ mod test {
                 tokens_provided: vec![
                     v1beta1::Coin {
                         denom: DENOM_BASE.to_string(),
-                        amount: "10000000000".to_string(),
+                        amount: TOKENS_PROVIDED_AMOUNT.to_string(),
                     },
                     v1beta1::Coin {
                         denom: DENOM_QUOTE.to_string(),
-                        amount: "10000000000".to_string(),
+                        amount: TOKENS_PROVIDED_AMOUNT.to_string(),
                     },
                 ],
                 token_min_amount0: Uint128::zero().to_string(),
@@ -124,8 +124,8 @@ mod test {
             // TODO: Evaluate creating a default_init() variant i.e. out_of_range_init()
             "./test-tube-build/wasm32-unknown-unknown/release/cl_vault.wasm",
             &[
-                Coin::new(1_000_000_000_000, DENOM_BASE),
-                Coin::new(1_000_000_000_000, DENOM_QUOTE),
+                Coin::new(ADMIN_BALANCE_AMOUNT, DENOM_BASE),
+                Coin::new(ADMIN_BALANCE_AMOUNT, DENOM_QUOTE),
             ],
             MsgCreateConcentratedPool {
                 sender: "overwritten".to_string(),
@@ -139,11 +139,11 @@ mod test {
             vec![
                 v1beta1::Coin {
                     denom: DENOM_BASE.to_string(),
-                    amount: "10000000000".to_string(),
+                    amount: TOKENS_PROVIDED_AMOUNT.to_string(),
                 },
                 v1beta1::Coin {
                     denom: DENOM_QUOTE.to_string(),
-                    amount: "10000000000".to_string(),
+                    amount: TOKENS_PROVIDED_AMOUNT.to_string(),
                 },
             ],
             Uint128::zero(),
@@ -162,11 +162,11 @@ mod test {
                 tokens_provided: vec![
                     v1beta1::Coin {
                         denom: DENOM_BASE.to_string(),
-                        amount: "10000000000".to_string(),
+                        amount: TOKENS_PROVIDED_AMOUNT.to_string(),
                     },
                     v1beta1::Coin {
                         denom: DENOM_QUOTE.to_string(),
-                        amount: "10000000000".to_string(),
+                        amount: TOKENS_PROVIDED_AMOUNT.to_string(),
                     },
                 ],
                 token_min_amount0: Uint128::zero().to_string(),
@@ -178,8 +178,8 @@ mod test {
 
         let alice = app
             .init_account(&[
-                Coin::new(1_000_000_000_000, DENOM_BASE),
-                Coin::new(1_000_000_000_000, DENOM_QUOTE),
+                Coin::new(ADMIN_BALANCE_AMOUNT, DENOM_BASE),
+                Coin::new(ADMIN_BALANCE_AMOUNT, DENOM_QUOTE),
             ])
             .unwrap();
 
@@ -248,8 +248,8 @@ mod test {
             // TODO: Evaluate creating a default_init() variant i.e. out_of_range_init()
             "./test-tube-build/wasm32-unknown-unknown/release/cl_vault.wasm",
             &[
-                Coin::new(1_000_000_000_000, DENOM_BASE),
-                Coin::new(1_000_000_000_000, DENOM_QUOTE),
+                Coin::new(ADMIN_BALANCE_AMOUNT, DENOM_BASE),
+                Coin::new(ADMIN_BALANCE_AMOUNT, DENOM_QUOTE),
             ],
             MsgCreateConcentratedPool {
                 sender: "overwritten".to_string(),
@@ -263,11 +263,11 @@ mod test {
             vec![
                 v1beta1::Coin {
                     denom: DENOM_BASE.to_string(),
-                    amount: "10000000000".to_string(),
+                    amount: TOKENS_PROVIDED_AMOUNT.to_string(),
                 },
                 v1beta1::Coin {
                     denom: DENOM_QUOTE.to_string(),
-                    amount: "10000000000".to_string(),
+                    amount: TOKENS_PROVIDED_AMOUNT.to_string(),
                 },
             ],
             Uint128::zero(),
@@ -287,11 +287,11 @@ mod test {
                 tokens_provided: vec![
                     v1beta1::Coin {
                         denom: DENOM_BASE.to_string(),
-                        amount: "10000000000".to_string(),
+                        amount: TOKENS_PROVIDED_AMOUNT.to_string(),
                     },
                     v1beta1::Coin {
                         denom: DENOM_QUOTE.to_string(),
-                        amount: "10000000000".to_string(),
+                        amount: TOKENS_PROVIDED_AMOUNT.to_string(),
                     },
                 ],
                 token_min_amount0: Uint128::zero().to_string(),
@@ -303,8 +303,8 @@ mod test {
 
         let alice = app
             .init_account(&[
-                Coin::new(1_000_000_000_000, DENOM_BASE),
-                Coin::new(1_000_000_000_000, DENOM_QUOTE),
+                Coin::new(ADMIN_BALANCE_AMOUNT, DENOM_BASE),
+                Coin::new(ADMIN_BALANCE_AMOUNT, DENOM_QUOTE),
             ])
             .unwrap();
 
@@ -365,8 +365,8 @@ mod test {
             // TODO: Evaluate using default_init()
             "./test-tube-build/wasm32-unknown-unknown/release/cl_vault.wasm",
             &[
-                Coin::new(1_000_000_000_000, DENOM_BASE),
-                Coin::new(1_000_000_000_000, DENOM_QUOTE),
+                Coin::new(ADMIN_BALANCE_AMOUNT, DENOM_BASE),
+                Coin::new(ADMIN_BALANCE_AMOUNT, DENOM_QUOTE),
             ],
             MsgCreateConcentratedPool {
                 sender: "overwritten".to_string(),

--- a/smart-contracts/contracts/cl-vault/src/test_tube/range.rs
+++ b/smart-contracts/contracts/cl-vault/src/test_tube/range.rs
@@ -25,6 +25,95 @@ mod test {
 
     #[test]
     #[ignore]
+    fn move_range_purge_cache_works() {
+        let (app, contract, cl_pool_id, admin) = init_test_contract(
+            // TODO: Evaluate creating a default_init() variant i.e. out_of_range_init()
+            "./test-tube-build/wasm32-unknown-unknown/release/cl_vault.wasm",
+            &[
+                Coin::new(1_000_000_000_000, "uatom"),
+                Coin::new(1_000_000_000_000, "uosmo"),
+            ],
+            MsgCreateConcentratedPool {
+                sender: "overwritten".to_string(),
+                denom0: "uatom".to_string(),
+                denom1: "uosmo".to_string(),
+                tick_spacing: 100,
+                spread_factor: Decimal::from_str("0.0001").unwrap().atomics().to_string(),
+            },
+            21205000,
+            27448000,
+            vec![
+                v1beta1::Coin {
+                    denom: "uatom".to_string(),
+                    amount: "10000000000".to_string(),
+                },
+                v1beta1::Coin {
+                    denom: "uosmo".to_string(),
+                    amount: "10000000000".to_string(),
+                },
+            ],
+            Uint128::zero(),
+            Uint128::zero(),
+        );
+
+        let wasm = Wasm::new(&app);
+        let cl = ConcentratedLiquidity::new(&app);
+
+        // Create a second position (in range) in the pool with the admin user to allow for swapping during update range operation
+        cl.create_position(
+            MsgCreatePosition {
+                pool_id: cl_pool_id,
+                sender: admin.address(),
+                lower_tick: -5000000,
+                upper_tick: 500000,
+                tokens_provided: vec![
+                    v1beta1::Coin {
+                        denom: "uatom".to_string(),
+                        amount: "10000000000".to_string(),
+                    },
+                    v1beta1::Coin {
+                        denom: "uosmo".to_string(),
+                        amount: "10000000000".to_string(),
+                    },
+                ],
+                token_min_amount0: Uint128::zero().to_string(),
+                token_min_amount1: Uint128::zero().to_string(),
+            },
+            &admin,
+        )
+        .unwrap();
+
+        // purge_tick_exp_cache
+        wasm.execute(
+            contract.as_str(),
+            &ExecuteMsg::VaultExtension(crate::msg::ExtensionExecuteMsg::PurgeTickExpCache {}),
+            &[],
+            &admin,
+        )
+        .unwrap();
+
+        let modify_range_resp = wasm
+            .execute(
+                contract.as_str(),
+                &ExecuteMsg::VaultExtension(crate::msg::ExtensionExecuteMsg::ModifyRange(
+                    ModifyRangeMsg {
+                        lower_price: Decimal::from_str("400").unwrap(),
+                        upper_price: Decimal::from_str("1466").unwrap(),
+                        max_slippage: Decimal::bps(9500),
+                        ratio_of_swappable_funds_to_use: Decimal::one(),
+                        twap_window_seconds: 45,
+                    },
+                )),
+                &[],
+                &admin,
+            )
+            .unwrap();
+
+        // TODO: Assert modify_range_resp
+    }
+
+    #[test]
+    #[ignore]
     fn move_range_works() {
         let (app, contract, cl_pool_id, admin) = init_test_contract(
             // TODO: Evaluate creating a default_init() variant i.e. out_of_range_init()

--- a/smart-contracts/contracts/cl-vault/src/test_tube/range.rs
+++ b/smart-contracts/contracts/cl-vault/src/test_tube/range.rs
@@ -23,6 +23,11 @@ mod test {
 
     use prost::Message;
 
+    const ADMIN_BALANCE_AMOUNT: u128 = 340282366920938463463374607431768211455u128;
+    const TOKENS_PROVIDED_AMOUNT: &str = "1000000000000";
+    const DENOM_BASE: &str = "uatom";
+    const DENOM_QUOTE: &str = "uosmo";
+
     #[test]
     #[ignore]
     fn move_range_purge_cache_works() {
@@ -30,13 +35,13 @@ mod test {
             // TODO: Evaluate creating a default_init() variant i.e. out_of_range_init()
             "./test-tube-build/wasm32-unknown-unknown/release/cl_vault.wasm",
             &[
-                Coin::new(1_000_000_000_000, "uatom"),
-                Coin::new(1_000_000_000_000, "uosmo"),
+                Coin::new(1_000_000_000_000, DENOM_BASE),
+                Coin::new(1_000_000_000_000, DENOM_QUOTE),
             ],
             MsgCreateConcentratedPool {
                 sender: "overwritten".to_string(),
-                denom0: "uatom".to_string(),
-                denom1: "uosmo".to_string(),
+                denom0: DENOM_BASE.to_string(),
+                denom1: DENOM_QUOTE.to_string(),
                 tick_spacing: 100,
                 spread_factor: Decimal::from_str("0.0001").unwrap().atomics().to_string(),
             },
@@ -44,11 +49,11 @@ mod test {
             27448000,
             vec![
                 v1beta1::Coin {
-                    denom: "uatom".to_string(),
+                    denom: DENOM_BASE.to_string(),
                     amount: "10000000000".to_string(),
                 },
                 v1beta1::Coin {
-                    denom: "uosmo".to_string(),
+                    denom: DENOM_QUOTE.to_string(),
                     amount: "10000000000".to_string(),
                 },
             ],
@@ -68,11 +73,11 @@ mod test {
                 upper_tick: 500000,
                 tokens_provided: vec![
                     v1beta1::Coin {
-                        denom: "uatom".to_string(),
+                        denom: DENOM_BASE.to_string(),
                         amount: "10000000000".to_string(),
                     },
                     v1beta1::Coin {
-                        denom: "uosmo".to_string(),
+                        denom: DENOM_QUOTE.to_string(),
                         amount: "10000000000".to_string(),
                     },
                 ],
@@ -119,13 +124,13 @@ mod test {
             // TODO: Evaluate creating a default_init() variant i.e. out_of_range_init()
             "./test-tube-build/wasm32-unknown-unknown/release/cl_vault.wasm",
             &[
-                Coin::new(1_000_000_000_000, "uatom"),
-                Coin::new(1_000_000_000_000, "uosmo"),
+                Coin::new(1_000_000_000_000, DENOM_BASE),
+                Coin::new(1_000_000_000_000, DENOM_QUOTE),
             ],
             MsgCreateConcentratedPool {
                 sender: "overwritten".to_string(),
-                denom0: "uatom".to_string(),
-                denom1: "uosmo".to_string(),
+                denom0: DENOM_BASE.to_string(),
+                denom1: DENOM_QUOTE.to_string(),
                 tick_spacing: 100,
                 spread_factor: Decimal::from_str("0.0001").unwrap().atomics().to_string(),
             },
@@ -133,11 +138,11 @@ mod test {
             27448000,
             vec![
                 v1beta1::Coin {
-                    denom: "uatom".to_string(),
+                    denom: DENOM_BASE.to_string(),
                     amount: "10000000000".to_string(),
                 },
                 v1beta1::Coin {
-                    denom: "uosmo".to_string(),
+                    denom: DENOM_QUOTE.to_string(),
                     amount: "10000000000".to_string(),
                 },
             ],
@@ -156,11 +161,11 @@ mod test {
                 upper_tick: 500000,
                 tokens_provided: vec![
                     v1beta1::Coin {
-                        denom: "uatom".to_string(),
+                        denom: DENOM_BASE.to_string(),
                         amount: "10000000000".to_string(),
                     },
                     v1beta1::Coin {
-                        denom: "uosmo".to_string(),
+                        denom: DENOM_QUOTE.to_string(),
                         amount: "10000000000".to_string(),
                     },
                 ],
@@ -173,8 +178,8 @@ mod test {
 
         let alice = app
             .init_account(&[
-                Coin::new(1_000_000_000_000, "uatom"),
-                Coin::new(1_000_000_000_000, "uosmo"),
+                Coin::new(1_000_000_000_000, DENOM_BASE),
+                Coin::new(1_000_000_000_000, DENOM_QUOTE),
             ])
             .unwrap();
 
@@ -185,10 +190,10 @@ mod test {
                 sender: alice.address(),
                 routes: vec![SwapAmountInRoute {
                     pool_id: cl_pool_id,
-                    token_out_denom: "uatom".to_string(),
+                    token_out_denom: DENOM_BASE.to_string(),
                 }],
                 token_in: Some(v1beta1::Coin {
-                    denom: "uosmo".to_string(),
+                    denom: DENOM_QUOTE.to_string(),
                     amount: "1000".to_string(),
                 }),
                 token_out_min_amount: "1".to_string(),
@@ -243,13 +248,13 @@ mod test {
             // TODO: Evaluate creating a default_init() variant i.e. out_of_range_init()
             "./test-tube-build/wasm32-unknown-unknown/release/cl_vault.wasm",
             &[
-                Coin::new(1_000_000_000_000, "uatom"),
-                Coin::new(1_000_000_000_000, "uosmo"),
+                Coin::new(1_000_000_000_000, DENOM_BASE),
+                Coin::new(1_000_000_000_000, DENOM_QUOTE),
             ],
             MsgCreateConcentratedPool {
                 sender: "overwritten".to_string(),
-                denom0: "uatom".to_string(),
-                denom1: "uosmo".to_string(),
+                denom0: DENOM_BASE.to_string(),
+                denom1: DENOM_QUOTE.to_string(),
                 tick_spacing: 100,
                 spread_factor: Decimal::from_str("0.0001").unwrap().atomics().to_string(),
             },
@@ -257,11 +262,11 @@ mod test {
             27448000,
             vec![
                 v1beta1::Coin {
-                    denom: "uatom".to_string(),
+                    denom: DENOM_BASE.to_string(),
                     amount: "10000000000".to_string(),
                 },
                 v1beta1::Coin {
-                    denom: "uosmo".to_string(),
+                    denom: DENOM_QUOTE.to_string(),
                     amount: "10000000000".to_string(),
                 },
             ],
@@ -281,11 +286,11 @@ mod test {
                 upper_tick: 500000,
                 tokens_provided: vec![
                     v1beta1::Coin {
-                        denom: "uatom".to_string(),
+                        denom: DENOM_BASE.to_string(),
                         amount: "10000000000".to_string(),
                     },
                     v1beta1::Coin {
-                        denom: "uosmo".to_string(),
+                        denom: DENOM_QUOTE.to_string(),
                         amount: "10000000000".to_string(),
                     },
                 ],
@@ -298,8 +303,8 @@ mod test {
 
         let alice = app
             .init_account(&[
-                Coin::new(1_000_000_000_000, "uatom"),
-                Coin::new(1_000_000_000_000, "uosmo"),
+                Coin::new(1_000_000_000_000, DENOM_BASE),
+                Coin::new(1_000_000_000_000, DENOM_QUOTE),
             ])
             .unwrap();
 
@@ -309,10 +314,10 @@ mod test {
                 sender: alice.address(),
                 routes: vec![SwapAmountInRoute {
                     pool_id: cl_pool_id,
-                    token_out_denom: "uatom".to_string(),
+                    token_out_denom: DENOM_BASE.to_string(),
                 }],
                 token_in: Some(v1beta1::Coin {
-                    denom: "uosmo".to_string(),
+                    denom: DENOM_QUOTE.to_string(),
                     amount: "1000".to_string(),
                 }),
                 token_out_min_amount: "1".to_string(),
@@ -360,13 +365,13 @@ mod test {
             // TODO: Evaluate using default_init()
             "./test-tube-build/wasm32-unknown-unknown/release/cl_vault.wasm",
             &[
-                Coin::new(1_000_000_000_000, "uatom"),
-                Coin::new(1_000_000_000_000, "uosmo"),
+                Coin::new(1_000_000_000_000, DENOM_BASE),
+                Coin::new(1_000_000_000_000, DENOM_QUOTE),
             ],
             MsgCreateConcentratedPool {
                 sender: "overwritten".to_string(),
-                denom0: "uatom".to_string(), //token0 is uatom
-                denom1: "uosmo".to_string(), //token1 is uosmo
+                denom0: DENOM_BASE.to_string(),  //token0 is uatom
+                denom1: DENOM_QUOTE.to_string(), //token1 is uosmo
                 tick_spacing: 100,
                 spread_factor: Decimal::from_str("0.0001").unwrap().atomics().to_string(),
             },
@@ -374,11 +379,11 @@ mod test {
             31500000, // 5500
             vec![
                 v1beta1::Coin {
-                    denom: "uatom".to_string(),
+                    denom: DENOM_BASE.to_string(),
                     amount: "1000000".to_string(),
                 },
                 v1beta1::Coin {
-                    denom: "uosmo".to_string(),
+                    denom: DENOM_QUOTE.to_string(),
                     amount: "1000000".to_string(),
                 },
             ],
@@ -387,8 +392,8 @@ mod test {
         );
         let alice = app
             .init_account(&[
-                Coin::new(1_000_000_000_000, "uatom"),
-                Coin::new(1_000_000_000_000, "uosmo"),
+                Coin::new(1_000_000_000_000, DENOM_BASE),
+                Coin::new(1_000_000_000_000, DENOM_QUOTE),
             ])
             .unwrap();
 
@@ -405,8 +410,8 @@ mod test {
             lower_tick: 30500000,
             upper_tick: 31500000,
             tokens_provided: vec![
-                coin(3349580, "uatom").into(),
-                coin(4280628569, "uosmo").into(),
+                coin(3349580, DENOM_BASE).into(),
+                coin(4280628569, DENOM_QUOTE).into(),
             ],
             token_min_amount0: "0".to_string(),
             token_min_amount1: "0".to_string(),

--- a/smart-contracts/contracts/cl-vault/src/test_tube/rewards.rs
+++ b/smart-contracts/contracts/cl-vault/src/test_tube/rewards.rs
@@ -9,21 +9,26 @@ mod tests {
     };
     use osmosis_test_tube::{Account, Module, PoolManager, Wasm};
 
+    const _ADMIN_BALANCE_AMOUNT: u128 = 340282366920938463463374607431768211455u128;
+    const _TOKENS_PROVIDED_AMOUNT: &str = "1000000000000";
+    const DENOM_BASE: &str = "uatom";
+    const DENOM_QUOTE: &str = "uosmo";
+
     #[test]
     #[ignore]
     fn test_rewards_single_distribute_claim() {
         let (app, contract_address, cl_pool_id, _admin) = default_init();
         let alice = app
             .init_account(&[
-                Coin::new(1_000_000_000_000, "uatom"),
-                Coin::new(1_000_000_000_000, "uosmo"),
+                Coin::new(1_000_000_000_000, DENOM_BASE),
+                Coin::new(1_000_000_000_000, DENOM_QUOTE),
             ])
             .unwrap();
 
         let bob = app
             .init_account(&[
-                Coin::new(1_000_000_000_000, "uatom"),
-                Coin::new(1_000_000_000_000, "uosmo"),
+                Coin::new(1_000_000_000_000, DENOM_BASE),
+                Coin::new(1_000_000_000_000, DENOM_QUOTE),
             ])
             .unwrap();
 
@@ -33,7 +38,10 @@ mod tests {
             .execute(
                 contract_address.as_str(),
                 &ExecuteMsg::ExactDeposit { recipient: None },
-                &[Coin::new(5_000_000, "uatom"), Coin::new(5_000_000, "uosmo")],
+                &[
+                    Coin::new(5_000_000, DENOM_BASE),
+                    Coin::new(5_000_000, DENOM_QUOTE),
+                ],
                 &alice,
             )
             .unwrap();
@@ -45,10 +53,10 @@ mod tests {
                     sender: bob.address(),
                     routes: vec![SwapAmountInRoute {
                         pool_id: cl_pool_id,
-                        token_out_denom: "uatom".to_string(),
+                        token_out_denom: DENOM_BASE.to_string(),
                     }],
                     token_in: Some(OsmoCoin {
-                        denom: "uosmo".to_string(),
+                        denom: DENOM_QUOTE.to_string(),
                         amount: "100".to_string(),
                     }),
                     token_out_min_amount: "1".to_string(),
@@ -63,10 +71,10 @@ mod tests {
                     sender: bob.address(),
                     routes: vec![SwapAmountInRoute {
                         pool_id: cl_pool_id,
-                        token_out_denom: "uatom".to_string(),
+                        token_out_denom: DENOM_BASE.to_string(),
                     }],
                     token_in: Some(OsmoCoin {
-                        denom: "uosmo".to_string(),
+                        denom: DENOM_QUOTE.to_string(),
                         amount: "100".to_string(),
                     }),
                     token_out_min_amount: "1".to_string(),
@@ -81,10 +89,10 @@ mod tests {
                     sender: bob.address(),
                     routes: vec![SwapAmountInRoute {
                         pool_id: cl_pool_id,
-                        token_out_denom: "uatom".to_string(),
+                        token_out_denom: DENOM_BASE.to_string(),
                     }],
                     token_in: Some(OsmoCoin {
-                        denom: "uosmo".to_string(),
+                        denom: DENOM_QUOTE.to_string(),
                         amount: "100".to_string(),
                     }),
                     token_out_min_amount: "1".to_string(),
@@ -99,10 +107,10 @@ mod tests {
                     sender: bob.address(),
                     routes: vec![SwapAmountInRoute {
                         pool_id: cl_pool_id,
-                        token_out_denom: "uosmo".to_string(),
+                        token_out_denom: DENOM_QUOTE.to_string(),
                     }],
                     token_in: Some(OsmoCoin {
-                        denom: "uatom".to_string(),
+                        denom: DENOM_BASE.to_string(),
                         amount: "100".to_string(),
                     }),
                     token_out_min_amount: "1".to_string(),
@@ -117,10 +125,10 @@ mod tests {
                     sender: bob.address(),
                     routes: vec![SwapAmountInRoute {
                         pool_id: cl_pool_id,
-                        token_out_denom: "uosmo".to_string(),
+                        token_out_denom: DENOM_QUOTE.to_string(),
                     }],
                     token_in: Some(OsmoCoin {
-                        denom: "uatom".to_string(),
+                        denom: DENOM_BASE.to_string(),
                         amount: "100".to_string(),
                     }),
                     token_out_min_amount: "1".to_string(),
@@ -135,10 +143,10 @@ mod tests {
                     sender: bob.address(),
                     routes: vec![SwapAmountInRoute {
                         pool_id: cl_pool_id,
-                        token_out_denom: "uosmo".to_string(),
+                        token_out_denom: DENOM_QUOTE.to_string(),
                     }],
                     token_in: Some(OsmoCoin {
-                        denom: "uatom".to_string(),
+                        denom: DENOM_BASE.to_string(),
                         amount: "100".to_string(),
                     }),
                     token_out_min_amount: "1".to_string(),

--- a/smart-contracts/contracts/cl-vault/src/vault/range.rs
+++ b/smart-contracts/contracts/cl-vault/src/vault/range.rs
@@ -251,14 +251,16 @@ pub fn handle_initial_create_position_reply(
     let target_upper_tick = create_position_message.upper_tick;
 
     // get refunded amounts
+    // TODO added saturating sub as work around for https://github.com/osmosis-labs/osmosis/issues/6843
+    // should be a checked sub eventually
     let current_balance = CURRENT_BALANCE.load(deps.storage)?;
     let refunded_amounts = (
         current_balance
             .0
-            .checked_sub(Uint128::from_str(&create_position_message.amount0)?)?,
+            .saturating_sub(Uint128::from_str(&create_position_message.amount0)?),
         current_balance
             .1
-            .checked_sub(Uint128::from_str(&create_position_message.amount1)?)?,
+            .saturating_sub(Uint128::from_str(&create_position_message.amount1)?),
     );
 
     do_swap_deposit_merge(

--- a/smart-contracts/contracts/cl-vault/src/vault/range.rs
+++ b/smart-contracts/contracts/cl-vault/src/vault/range.rs
@@ -342,7 +342,6 @@ pub fn do_swap_deposit_merge(
         (
             // current tick is above range
             if pool_details.current_tick < target_lower_tick {
-                // TODO: Maybe here <= ?
                 balance1
             } else {
                 get_single_sided_deposit_1_to_0_swap_amount(


### PR DESCRIPTION
## 1. Overview

1. **Updated `.cargo/config`:**
   - Modified `test-tube` command to use `--test-threads=1`, limiting the number of test threads to avoid nondeterminism.

3. **Enhancements in `contract.rs`:**
   - Added new executable message: `PurgeTickExpCache`.
   - Integrated `purge_tick_exp_cache` from `math::tick`.

4. **Improvements in Error Handling (`error.rs`):**
   - Added `TickNotFoundAfterRebuild` error for enhanced error handling.

5. **Major Updates in `tick.rs` (math directory):**
   - Adjustments in `price_to_tick` function.
   - New method to purge tick exponential cache.

6. **New Message Type in `msg.rs`:**
   - Introduced `PurgeTickExpCache` message for cache purging.

7. **Refinements in `initialize.rs` (test_tube directory):**
   - Asserting an initial spot price of 1.0 on `init_test_contract()`

8. **Updates in `proptest.rs` (test_tube directory):**
   - Adjusted constants and test range parameters to avoid liquidityDelta and out of tick error.
   - Reduced number of test executions from 256 to 100

## 2. Implementation details

<!-- Describe the implementation (highlights only) as well as design rationale. -->

## 3. How to test/use

<!-- How can people test/use this? -->

## 4. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?

## 5. Limitations (optional)

<!-- Describe any limitation of the capabilities listed in the Overview section. -->

## 6. Future Work (optional)

<!-- Describe follow up work, if any. -->