### PR TITLE
Feature/update wasm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG RUNNER_IMAGE="gcr.io/distroless/static-debian11"
 # Builder
 # --------------------------------------------------------
 
-FROM golang:${GO_VERSION}-alpine as builder
+FROM golang:${GO_VERSION}-alpine3.18 as builder
 
 ARG GIT_VERSION
 ARG GIT_COMMIT

--- a/app/app.go
+++ b/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
 
@@ -601,7 +602,7 @@ func New(
 
 	// The last arguments can contain custom message handlers, and custom query handlers,
 	// if we want to allow any custom callbacks
-	supportedFeatures := "iterator,staking,stargate"
+	supportedFeatures := "iterator,staking,stargate,osmosis,cosmwasm_1_1,cosmwasm_1_2,cosmwasm_1_4"
 	app.WasmKeeper = wasm.NewKeeper(
 		appCodec,
 		keys[wasm.StoreKey],

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 )
 
 require (
-	github.com/CosmWasm/wasmvm v1.2.1
+	github.com/CosmWasm/wasmvm v1.2.6
 	github.com/cosmos/cosmos-proto v1.0.0-beta.2
 	github.com/cosmos/gogoproto v1.4.6
 	github.com/strangelove-ventures/async-icq/v4 v4.0.0-rc0

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mo
 github.com/CloudyKit/jet/v3 v3.0.0/go.mod h1:HKQPgSJmdK8hdoAbKUUWajkHyHo4RaU5rMdUywE7VMo=
 github.com/CosmWasm/wasmd v0.31.0 h1:xACf6A/SkCeGWQWrKGsR4X9PQb5G4XYuNfnrl+HQ1mE=
 github.com/CosmWasm/wasmd v0.31.0/go.mod h1:VcyDGk/ISVlMUeW+1GGL0zdHWBS2FPwLEV2qZ86l7l8=
-github.com/CosmWasm/wasmvm v1.2.1 h1:si0tRsRDdUShV0k51Wn6zRKlmj3/WWP9Yr4cLmDTf+8=
-github.com/CosmWasm/wasmvm v1.2.1/go.mod h1:vW/E3h8j9xBQs9bCoijDuawKo9kCtxOaS8N8J7KFtkc=
+github.com/CosmWasm/wasmvm v1.2.6 h1:QmOaiJUyeh8+pPCjJBTgWrbi/hCzCuWewduDO85Pcpc=
+github.com/CosmWasm/wasmvm v1.2.6/go.mod h1:KO0zfQgCsQ6urWL1MYLlGqRgr7R4an6jo+LWRZjfD4c=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=


### PR DESCRIPTION
## 1. Overview

1. Adding the was capability support on chain for x/wasm osmosis,cosmwasm_1_1,cosmwasm_1_2,cosmwasm_1_4. 
2. Patct the wasm version  
3. Fixed docker build.

## 2. Implementation details

1. Append the new supported features in the wasm Keeper.
2. update go.mod for github.com/CosmWasm/wasmvm v1.2.6
3. Used the correct version of alpine in Dockerfile
## 3. How to test/use

1. Patch update test by changing the binary.
2. store code the any of the .wasm files with supported feature. Use daodao tag 2.3.0
 

## 4. Checklist

 

 

## 5. Limitations (optional)

 
## 6. Future Work (optional)

 