### PR TITLE
add dao contracts into monorepo for easy test tube integrations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "smart-contracts/external_deps/dao-contracts"]
+	path = smart-contracts/external_deps/dao-contracts
+	url = https://github.com/magiodev/dao-contracts.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "smart-contracts/external_deps/dao-contracts"]
 	path = smart-contracts/external_deps/dao-contracts
-	url = https://github.com/magiodev/dao-contracts.git
+	url = https://github.com/quasar-finance/dao-contracts


### PR DESCRIPTION
## 1. Overview

Adding DAO contracts into our monorepo as a submodule

Reasoning:
* we get all the benefits of being forked from the original dao contracts repo (and being able to pull updates as needed)
* while also being able to run a full end to end test with test tube without needing a specific project structure outside of a git repo


In order to pull the submodule when you checkout this branch run 
`git submodule update --remote`

This will check out and download the main branch

## further improvements:

We can also have the entire workspace be built by adding a dummy contract into `smart/contracts/dao-contracts` that looks like this:

```
| contracts
│   ├── dao-contracts
│   │   ├── Cargo.toml
│   │   └── src
│   │       └── lib.rs
```

And specify our deps in Cargo.toml like so:

```
[dependencies]
dao-contracts-dependency = {path = "../../external_deps/dao-contracts"}
```