### PR TITLE
fix: add saturating sub in withdraw reply logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - fix/*
   push:
     branches:
       - main
+      - fix/*
   workflow_dispatch:
 
 concurrency:

--- a/smart-contracts/Cargo.lock
+++ b/smart-contracts/Cargo.lock
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9934c79e58d9676edfd592557dee765d2a6ef54c09d5aa2edb06156b00148966"
+checksum = "e6b4c3f9c4616d6413d4b5fc4c270a4cc32a374b9be08671e80e1a019f805d8f"
 dependencies = [
  "digest 0.10.7",
  "ecdsa",
@@ -388,18 +388,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5e72e330bd3bdab11c52b5ecbdeb6a8697a004c57964caeb5d876f0b088b3c"
+checksum = "c586ced10c3b00e809ee664a895025a024f60d65d34fe4c09daed4a4db68a3f3"
 dependencies = [
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e3a2136e2a60e8b6582f5dffca5d1a683ed77bf38537d330bc1dfccd69010"
+checksum = "8467874827d384c131955ff6f4d47d02e72a956a08eb3c0ff24f8c903a5517b4"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -410,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d803bea6bd9ed61bd1ee0b4a2eb09ee20dbb539cc6e0b8795614d20952ebb1"
+checksum = "f6db85d98ac80922aef465e564d5b21fa9cfac5058cb62df7f116c3682337393"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8666e572a3a2519010dde88c04d16e9339ae751b56b2bb35081fe3f7d6be74"
+checksum = "712fe58f39d55c812f7b2c84e097cdede3a39d520f89b6dc3153837e31741927"
 dependencies = [
  "base64 0.21.7",
  "bech32",

--- a/smart-contracts/Cargo.toml
+++ b/smart-contracts/Cargo.toml
@@ -19,8 +19,8 @@ members = [
 
 [workspace.dependencies]
 # CosmWasm
-cosmwasm-std = "1.5.3"
-cosmwasm-schema = "1.5.3"
+cosmwasm-std = "1.5.4"
+cosmwasm-schema = "1.5.4"
 cosmwasm-storage = "1.5.2"
 cw-storage-plus = "1.2.0"
 cw-controllers = "1.1.2"

--- a/smart-contracts/contracts/cl-vault/src/vault/range.rs
+++ b/smart-contracts/contracts/cl-vault/src/vault/range.rs
@@ -154,11 +154,11 @@ pub fn handle_withdraw_position_reply(
     let unused_balance0 = unused_balances
         .find_coin(pool_config.token0.clone())
         .amount
-        .checked_sub(amount0)?;
+        .saturating_sub(amount0);
     let unused_balance1 = unused_balances
         .find_coin(pool_config.token1.clone())
         .amount
-        .checked_sub(amount1)?;
+        .saturating_sub(amount1);
 
     amount0 = amount0.checked_add(unused_balance0)?;
     amount1 = amount1.checked_add(unused_balance1)?;


### PR DESCRIPTION
## 1. Overview
- add saturating sub in withdraw reply logic while range update.
- comswasm deps bump to 1.5.4 in accordance to advisory
<!-- What are you changing, removing, or adding in this review? -->

## 2. Implementation details
- We are getting a erroneous repsonse in `MsgWithdrawPositionResponse`  which is creating a off by 1 err

<!-- Describe the implementation (highlights only) as well as design rationale. -->

## 3. How to test/use

<!-- How can people test/use this? -->

## 4. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?

## 5. Limitations (optional)

<!-- Describe any limitation of the capabilities listed in the Overview section. -->

## 6. Future Work (optional)

<!-- Describe follow up work, if any. -->