### PR TITLE
fix: migrate entrypoints in `cl-vault` and `range-middleware`

### DIFF
--- a/smart-contracts/contracts/cl-vault/src/contract.rs
+++ b/smart-contracts/contracts/cl-vault/src/contract.rs
@@ -1,6 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response};
+use cosmwasm_std::{
+    to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, Uint128,
+};
 use cw2::set_contract_version;
 
 use crate::error::{ContractError, ContractResult};
@@ -16,9 +18,10 @@ use crate::query::{
 use crate::reply::Replies;
 use crate::rewards::{
     execute_collect_rewards, execute_distribute_rewards, handle_collect_incentives_reply,
-    handle_collect_spread_rewards_reply,
+    handle_collect_spread_rewards_reply, CoinList,
 };
 
+use crate::state::{RewardsStatus, CURRENT_TOTAL_SUPPLY, DISTRIBUTED_REWARDS, REWARDS_STATUS};
 use crate::vault::admin::execute_admin;
 use crate::vault::claim::execute_claim_user_rewards;
 use crate::vault::deposit::{execute_exact_deposit, handle_deposit_create_position_reply};
@@ -192,6 +195,9 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    Ok(Response::default())
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    REWARDS_STATUS.save(deps.storage, &RewardsStatus::Ready)?;
+    DISTRIBUTED_REWARDS.save(deps.storage, &CoinList::new())?;
+    CURRENT_TOTAL_SUPPLY.save(deps.storage, &Uint128::zero())?;
+    Ok(Response::new().add_attribute("migrate", "successful"))
 }

--- a/smart-contracts/contracts/range-middleware/src/contract.rs
+++ b/smart-contracts/contracts/range-middleware/src/contract.rs
@@ -7,7 +7,7 @@ use cw2::set_contract_version;
 use crate::admin::execute::execute_admin_msg;
 use crate::admin::query::query_admin;
 use crate::error::ContractError;
-use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::range::execute::execute_range_msg;
 use crate::range::query::query_range;
 use crate::state::{RANGE_EXECUTOR_ADMIN, RANGE_SUBMITTER_ADMIN};
@@ -56,6 +56,11 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::RangeQuery(range_query) => query_range(deps, env, range_query),
         QueryMsg::AdminQuery(admin_query) => query_admin(deps, env, admin_query),
     }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    Ok(Response::default())
 }
 
 #[cfg(test)]

--- a/smart-contracts/contracts/range-middleware/src/msg.rs
+++ b/smart-contracts/contracts/range-middleware/src/msg.rs
@@ -30,3 +30,6 @@ pub enum QueryMsg {
     #[returns(Empty)]
     AdminQuery(AdminQueryMsg),
 }
+
+#[cw_serde]
+pub struct MigrateMsg {}


### PR DESCRIPTION
## 1. Overview
- adds migrate entrypoint in `range-middleware`
- fixes the migration entrypoint in `cl-vault`
<!-- What are you changing, removing, or adding in this review? -->

## 2. Implementation details
- The `range-middleware` contract was missing migrate entry point this PR adds an empty migrate entrypoint with subsequent `MigrateMsg`
- A migration to initialise the paginated distribution states is added in `cl-vault`

<!-- Describe the implementation (highlights only) as well as design rationale. -->

## 3. How to test/use

<!-- How can people test/use this? -->

## 4. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?

## 5. Limitations (optional)

<!-- Describe any limitation of the capabilities listed in the Overview section. -->

## 6. Future Work (optional)

<!-- Describe follow up work, if any. -->