### PR TITLE
add authz interface

### DIFF
--- a/smart-contracts/contracts/cl-vault/src/contract.rs
+++ b/smart-contracts/contracts/cl-vault/src/contract.rs
@@ -85,6 +85,18 @@ pub fn execute(
                 crate::msg::ExtensionExecuteMsg::Admin(admin_msg) => {
                     execute_admin(deps, info, admin_msg)
                 }
+                crate::msg::ExtensionExecuteMsg::Authz(msg) => match msg {
+                    crate::msg::AuthzExtension::ExactDeposit {} => {
+                        execute_any_deposit(deps, env, info, None)
+                    }
+                    crate::msg::AuthzExtension::AnyDeposit {} => {
+                        execute_exact_deposit(deps, env, info, None)
+                    }
+                    crate::msg::AuthzExtension::Redeem { amount } => prepend_claim_msg(
+                        &env,
+                        execute_withdraw(deps, &env, info, None, amount.into())?,
+                    ),
+                },
                 crate::msg::ExtensionExecuteMsg::Merge(msg) => {
                     execute_merge_position(deps, env, info, msg)
                 }

--- a/smart-contracts/contracts/cl-vault/src/msg.rs
+++ b/smart-contracts/contracts/cl-vault/src/msg.rs
@@ -23,6 +23,8 @@ pub struct SwapAsset {
 pub enum ExtensionExecuteMsg {
     /// Execute Admin operations.
     Admin(AdminExtensionExecuteMsg),
+    /// An interface of certain vault interaction with forced values for authz
+    Authz(AuthzExtension),
     /// Rebalance our liquidity range based on an off-chain message
     /// given to us by RANGE_ADMIN
     ModifyRange(ModifyRangeMsg),
@@ -41,6 +43,15 @@ pub enum ExtensionExecuteMsg {
         force_swap_route: bool,
         swap_routes: Vec<SwapAsset>,
     },
+}
+
+/// Extension messages for Authz. This interface basically reexports certain vault functionality
+/// but sets recipient forcibly to None
+#[cw_serde]
+pub enum AuthzExtension {
+    ExactDeposit {},
+    AnyDeposit {},
+    Redeem { amount: Uint128 },
 }
 
 /// Apollo extension messages define functionality that is part of all apollo


### PR DESCRIPTION
## 1. Overview

Adds an authz deposit interface that calls the same methods as exact deposit, any deposit and withdraw

## 2. Implementation details

Adds an extra nested enum that internally calls the same functions
