### PR TITLE
Feat/cl vault range calc swap

### DIFF
--- a/smart-contracts/contracts/cl-vault/src/contract.rs
+++ b/smart-contracts/contracts/cl-vault/src/contract.rs
@@ -23,6 +23,8 @@ use crate::reply::Replies;
 #[allow(deprecated)]
 use crate::state::CURRENT_BALANCE;
 #[allow(deprecated)]
+use crate::state::CURRENT_SWAP;
+#[allow(deprecated)]
 use crate::state::{
     MigrationStatus, VaultConfig, MIGRATION_STATUS, OLD_VAULT_CONFIG, STRATEGIST_REWARDS,
     VAULT_CONFIG,
@@ -289,6 +291,8 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, Co
     OLD_POSITION.remove(deps.storage);
     #[allow(deprecated)]
     CURRENT_BALANCE.remove(deps.storage);
+    #[allow(deprecated)]
+    CURRENT_SWAP.remove(deps.storage);
 
     Ok(response)
 }
@@ -364,6 +368,8 @@ mod tests {
         OLD_POSITION.remove(deps.storage);
         #[allow(deprecated)]
         CURRENT_BALANCE.remove(deps.storage);
+        #[allow(deprecated)]
+        CURRENT_SWAP.remove(deps.storage);
 
         Ok(response)
     }
@@ -418,6 +424,10 @@ mod tests {
         #[allow(deprecated)]
         let current_balance = CURRENT_BALANCE.may_load(deps.as_mut().storage).unwrap();
         assert!(current_balance.is_none());
+
+        #[allow(deprecated)]
+        let current_swap = CURRENT_SWAP.may_load(deps.as_mut().storage).unwrap();
+        assert!(current_swap.is_none());
     }
 
     #[test]

--- a/smart-contracts/contracts/cl-vault/src/helpers/getters.rs
+++ b/smart-contracts/contracts/cl-vault/src/helpers/getters.rs
@@ -144,11 +144,6 @@ pub fn get_single_sided_deposit_0_to_1_swap_amount(
     current_tick: i64,
     upper_tick: i64,
 ) -> Result<Uint128, ContractError> {
-    // TODO error here if this condition holds
-    // if current_tick < lower_tick {
-    //     return ;
-    // }
-
     let lower_price = tick_to_price(lower_tick)?;
     let current_price = tick_to_price(current_tick)?;
     let upper_price = tick_to_price(upper_tick)?;
@@ -156,11 +151,6 @@ pub fn get_single_sided_deposit_0_to_1_swap_amount(
     let cur_price_sqrt = current_price.sqrt();
     let lower_price_sqrt = lower_price.sqrt();
     let upper_price_sqrt = upper_price.sqrt();
-
-    // let pool_metadata_constant: Decimal256 = cur_price_sqrt
-    //     .checked_mul(lower_price_sqrt)?
-    //     .checked_mul(cur_price_sqrt.checked_sub(lower_price_sqrt)?)?
-    //     .checked_div(upper_price_sqrt.checked_sub(cur_price_sqrt)?)?;
 
     let pool_metadata_constant: Decimal256 = (upper_price_sqrt
         .checked_mul(cur_price_sqrt)?

--- a/smart-contracts/contracts/cl-vault/src/state.rs
+++ b/smart-contracts/contracts/cl-vault/src/state.rs
@@ -24,6 +24,9 @@ pub const USER_REWARDS: Map<Addr, CoinList> = Map::new("user_rewards");
 #[deprecated]
 pub const CURRENT_BALANCE: Item<(Uint128, Uint128)> = Item::new("current_balance"); // CURRENT_BALANCE is intended as CURRENT_SWAP_BALANCE
 
+#[deprecated]
+pub const CURRENT_SWAP: Item<(SwapDirection, Uint128)> = Item::new("current_swap");
+
 /// metadata useful for display purposes
 #[cw_serde]
 pub struct Metadata {
@@ -134,7 +137,6 @@ pub enum RewardsStatus {
 }
 
 /// Swap helper states
-pub const CURRENT_SWAP: Item<(SwapDirection, Uint128)> = Item::new("current_swap");
 pub const CURRENT_SWAP_ANY_DEPOSIT: Item<(SwapDirection, Uint128, Addr, (Uint128, Uint128))> =
     Item::new("current_swap_any_deposit");
 


### PR DESCRIPTION
## 1. Overview

This PR optimizes the way we create the next position during a ModifyRange operation, removing dangerous math operations by reading contract balances instead, leveraging the fact that in the reply we already updated balances after the reply_on_success has been called.

## 2. Implementation details

<!-- Describe the implementation (highlights only) as well as design rationale. -->

## 3. How to test/use

<!-- How can people test/use this? -->

## 4. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?

## 5. Limitations (optional)

<!-- Describe any limitation of the capabilities listed in the Overview section. -->

## 6. Future Work (optional)

<!-- Describe follow up work, if any. -->