### PR TITLE
switch `swap-non-vault-funds` entrypoint  permissionless

### DIFF
--- a/smart-contracts/osmosis/contracts/cl-vault/src/contract.rs
+++ b/smart-contracts/osmosis/contracts/cl-vault/src/contract.rs
@@ -137,7 +137,7 @@ pub fn execute(
                     )?,
                 ),
                 crate::msg::ExtensionExecuteMsg::SwapNonVaultFunds { swap_operations } => {
-                    execute_swap_non_vault_funds(deps, env, info, swap_operations)
+                    execute_swap_non_vault_funds(deps, env.contract.address, swap_operations)
                 }
                 crate::msg::ExtensionExecuteMsg::CollectRewards {} => {
                     execute_collect_rewards(deps, env)

--- a/smart-contracts/osmosis/contracts/cl-vault/src/helpers/msgs.rs
+++ b/smart-contracts/osmosis/contracts/cl-vault/src/helpers/msgs.rs
@@ -58,7 +58,11 @@ pub fn refund_bank_msg(
 
 /// swap will always swap over the CL pool. In the future we may expand the
 /// feature such that it chooses best swaps over all routes
-pub fn swap_msg(deps: &DepsMut, env: &Env, params: SwapParams) -> Result<CosmosMsg, ContractError> {
+pub fn swap_msg(
+    deps: &DepsMut,
+    contract_address: Addr,
+    params: SwapParams,
+) -> Result<CosmosMsg, ContractError> {
     // let pool_config = POOL_CONFIG.load(deps.storage)?;
     let dex_router = DEX_ROUTER.may_load(deps.storage)?;
 
@@ -71,7 +75,7 @@ pub fn swap_msg(deps: &DepsMut, env: &Env, params: SwapParams) -> Result<CosmosM
     // if we don't have a dex_router, we will always swap over the osmosis pool
     if dex_router.is_none() {
         return Ok(osmosis_swap_exact_amount_in_msg(
-            env,
+            contract_address,
             pool_route,
             params.token_in_amount,
             &params.token_in_denom.to_string(),
@@ -91,14 +95,14 @@ pub fn swap_msg(deps: &DepsMut, env: &Env, params: SwapParams) -> Result<CosmosM
 }
 
 fn osmosis_swap_exact_amount_in_msg(
-    env: &Env,
+    contract_address: Addr,
     pool_route: SwapAmountInRoute,
     token_in_amount: Uint128,
     token_in_denom: &String,
     token_out_min_amount: Uint128,
 ) -> CosmosMsg {
     osmosis_std::types::osmosis::poolmanager::v1beta1::MsgSwapExactAmountIn {
-        sender: env.contract.address.to_string(),
+        sender: contract_address.to_string(),
         routes: vec![pool_route],
         token_in: Some(OsmoCoin {
             denom: token_in_denom.to_string(),

--- a/smart-contracts/osmosis/contracts/cl-vault/src/vault/any_deposit.rs
+++ b/smart-contracts/osmosis/contracts/cl-vault/src/vault/any_deposit.rs
@@ -333,7 +333,7 @@ fn calculate_swap_amount(
     // pool on which the vault is running
     let swap_msg = swap_msg(
         &deps,
-        env,
+        env.contract.address.clone(),
         SwapParams {
             pool_id: pool_config.pool_id,
             token_in_amount,

--- a/smart-contracts/osmosis/contracts/cl-vault/src/vault/range.rs
+++ b/smart-contracts/osmosis/contracts/cl-vault/src/vault/range.rs
@@ -421,7 +421,7 @@ fn calculate_swap_amount(
 
     let swap_msg = swap_msg(
         &deps,
-        &env,
+        env.contract.address.clone(),
         SwapParams {
             pool_id: pool_config.pool_id,
             token_in_amount,


### PR DESCRIPTION
## 1. Overview
- make the `swap_non_vault_funds` permissionless.
- idea behind this is so that the swap process can be automated and thus efficiently autocompounded (via cronjob)
<!-- What are you changing, removing, or adding in this review? -->

## 2. Implementation details
- remove the assertion from range admin

<!-- Describe the implementation (highlights only) as well as design rationale. -->

## 3. How to test/use

<!-- How can people test/use this? -->

## 4. Checklist
- NA
<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?

## 5. Limitations (optional)

<!-- Describe any limitation of the capabilities listed in the Overview section. -->

## 6. Future Work (optional)

<!-- Describe follow up work, if any. -->