### PR TITLE
Use dex-router in test-tube tests

### DIFF
--- a/smart-contracts/osmosis/contracts/cl-vault/schema/cl-vault.json
+++ b/smart-contracts/osmosis/contracts/cl-vault/schema/cl-vault.json
@@ -78,7 +78,8 @@
           "performance_fee",
           "swap_admin",
           "swap_max_slippage",
-          "treasury"
+          "treasury",
+          "twap_window_seconds"
         ],
         "properties": {
           "dex_router": {
@@ -95,6 +96,11 @@
           },
           "treasury": {
             "$ref": "#/definitions/Addr"
+          },
+          "twap_window_seconds": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           }
         },
         "additionalProperties": false
@@ -727,7 +733,8 @@
           "performance_fee",
           "swap_admin",
           "swap_max_slippage",
-          "treasury"
+          "treasury",
+          "twap_window_seconds"
         ],
         "properties": {
           "dex_router": {
@@ -744,6 +751,11 @@
           },
           "treasury": {
             "$ref": "#/definitions/Addr"
+          },
+          "twap_window_seconds": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           }
         },
         "additionalProperties": false
@@ -1122,11 +1134,17 @@
     "title": "MigrateMsg",
     "type": "object",
     "required": [
-      "swap_admin"
+      "swap_admin",
+      "twap_window_seconds"
     ],
     "properties": {
       "swap_admin": {
         "$ref": "#/definitions/Addr"
+      },
+      "twap_window_seconds": {
+        "type": "integer",
+        "format": "uint64",
+        "minimum": 0.0
       }
     },
     "additionalProperties": false,

--- a/smart-contracts/osmosis/contracts/cl-vault/schema/raw/execute.json
+++ b/smart-contracts/osmosis/contracts/cl-vault/schema/raw/execute.json
@@ -624,7 +624,8 @@
         "performance_fee",
         "swap_admin",
         "swap_max_slippage",
-        "treasury"
+        "treasury",
+        "twap_window_seconds"
       ],
       "properties": {
         "dex_router": {
@@ -641,6 +642,11 @@
         },
         "treasury": {
           "$ref": "#/definitions/Addr"
+        },
+        "twap_window_seconds": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         }
       },
       "additionalProperties": false

--- a/smart-contracts/osmosis/contracts/cl-vault/schema/raw/instantiate.json
+++ b/smart-contracts/osmosis/contracts/cl-vault/schema/raw/instantiate.json
@@ -74,7 +74,8 @@
         "performance_fee",
         "swap_admin",
         "swap_max_slippage",
-        "treasury"
+        "treasury",
+        "twap_window_seconds"
       ],
       "properties": {
         "dex_router": {
@@ -91,6 +92,11 @@
         },
         "treasury": {
           "$ref": "#/definitions/Addr"
+        },
+        "twap_window_seconds": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         }
       },
       "additionalProperties": false

--- a/smart-contracts/osmosis/contracts/cl-vault/schema/raw/migrate.json
+++ b/smart-contracts/osmosis/contracts/cl-vault/schema/raw/migrate.json
@@ -3,11 +3,17 @@
   "title": "MigrateMsg",
   "type": "object",
   "required": [
-    "swap_admin"
+    "swap_admin",
+    "twap_window_seconds"
   ],
   "properties": {
     "swap_admin": {
       "$ref": "#/definitions/Addr"
+    },
+    "twap_window_seconds": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
     }
   },
   "additionalProperties": false,

--- a/smart-contracts/osmosis/contracts/cl-vault/tests/test-tube/any_deposit.rs
+++ b/smart-contracts/osmosis/contracts/cl-vault/tests/test-tube/any_deposit.rs
@@ -1,6 +1,6 @@
 use crate::setup::{
-    fixture_dex_router, ACCOUNTS_INIT_BALANCE, ACCOUNTS_NUM, DENOM_BASE, DENOM_QUOTE,
-    MAX_SLIPPAGE_HIGH, PERFORMANCE_FEE_DEFAULT,
+    fixture_default, fixture_dex_router, ACCOUNTS_INIT_BALANCE, ACCOUNTS_NUM, DENOM_BASE,
+    DENOM_QUOTE, MAX_SLIPPAGE_HIGH, PERFORMANCE_FEE_DEFAULT,
 };
 
 use cl_vault::msg::ExecuteMsg;
@@ -25,8 +25,8 @@ fn test_any_deposit() {
     ];
 
     for (amount_base, amount_quote) in test_cases {
-        let (app, contract_address, _dex_router_addr, vault_pool_id, _pools_ids, admin, _) =
-            fixture_dex_router(PERFORMANCE_FEE_DEFAULT);
+        let (app, contract_address, vault_pool_id, admin, ..) =
+            fixture_default(PERFORMANCE_FEE_DEFAULT);
 
         do_and_verify_any_deposit(
             app,

--- a/smart-contracts/osmosis/contracts/cl-vault/tests/test-tube/authz.rs
+++ b/smart-contracts/osmosis/contracts/cl-vault/tests/test-tube/authz.rs
@@ -1,5 +1,6 @@
 use crate::setup::{
-    fixture_default, get_amount_from_denom, DENOM_BASE, DENOM_QUOTE, PERFORMANCE_FEE_DEFAULT,
+    fixture_default, fixture_dex_router, get_amount_from_denom, DENOM_BASE, DENOM_QUOTE,
+    PERFORMANCE_FEE_DEFAULT,
 };
 
 use cl_vault::{
@@ -20,7 +21,7 @@ const INITIAL_BALANCE_AMOUNT: u128 = 1_000_000_000_000_000_000_000_000_000_000;
 
 #[test]
 fn exact_deposit_withdraw_equal() {
-    let (app, contract_address, _cl_pool_id, _admin, _) = fixture_default(PERFORMANCE_FEE_DEFAULT);
+    let (app, contract_address, ..) = fixture_dex_router(PERFORMANCE_FEE_DEFAULT);
     let wasm = Wasm::new(&app);
 
     let alice = app
@@ -120,7 +121,7 @@ fn exact_deposit_withdraw_equal() {
 
 #[test]
 fn any_deposit_withdraw_equal() {
-    let (app, contract_address, _cl_pool_id, _admin, _) = fixture_default(PERFORMANCE_FEE_DEFAULT);
+    let (app, contract_address, ..) = fixture_default(PERFORMANCE_FEE_DEFAULT);
     let wasm = Wasm::new(&app);
 
     // Create Alice account

--- a/smart-contracts/osmosis/contracts/cl-vault/tests/test-tube/autocompound.rs
+++ b/smart-contracts/osmosis/contracts/cl-vault/tests/test-tube/autocompound.rs
@@ -292,16 +292,10 @@ fn test_autocompound_with_rewards_swap_non_vault_funds() {
                 token_in_denom: DENOM_REWARD.to_string(),
                 pool_id_base: swap_pools_ids[1],
                 pool_id_quote: swap_pools_ids[2],
-                forced_swap_route_base: Some(vec![
-                    SwapAmountInRoute {
-                        pool_id: swap_pools_ids[2],
-                        token_out_denom: DENOM_QUOTE.to_string(),
-                    },
-                    SwapAmountInRoute {
-                        pool_id: swap_pools_ids[1],
-                        token_out_denom: DENOM_BASE.to_string(),
-                    },
-                ]),
+                forced_swap_route_base: Some(vec![SwapAmountInRoute {
+                    pool_id: swap_pools_ids[1],
+                    token_out_denom: DENOM_BASE.to_string(),
+                }]),
                 forced_swap_route_quote: Some(vec![SwapAmountInRoute {
                     pool_id: swap_pools_ids[2],
                     token_out_denom: DENOM_QUOTE.to_string(),

--- a/smart-contracts/osmosis/contracts/cl-vault/tests/test-tube/initialize.rs
+++ b/smart-contracts/osmosis/contracts/cl-vault/tests/test-tube/initialize.rs
@@ -1,5 +1,5 @@
 use crate::setup::{
-    fixture_default, DENOM_BASE, DENOM_QUOTE, MAX_SLIPPAGE_HIGH, PERFORMANCE_FEE_DEFAULT,
+    fixture_dex_router, DENOM_BASE, DENOM_QUOTE, MAX_SLIPPAGE_HIGH, PERFORMANCE_FEE_DEFAULT,
 };
 
 use cl_vault::{
@@ -25,8 +25,9 @@ use osmosis_test_tube::{
 use std::str::FromStr;
 
 #[test]
-fn fixture_default_works() {
-    let (app, contract_address, cl_pool_id, admin, _) = fixture_default(PERFORMANCE_FEE_DEFAULT);
+fn fixture_dex_router_works() {
+    let (app, contract_address, _dex_router, cl_pool_id, _pools, admin, ..) =
+        fixture_dex_router(PERFORMANCE_FEE_DEFAULT);
     let wasm = Wasm::new(&app);
     let cl = ConcentratedLiquidity::new(&app);
     let tf = TokenFactory::new(&app);

--- a/smart-contracts/osmosis/contracts/cl-vault/tests/test-tube/range.rs
+++ b/smart-contracts/osmosis/contracts/cl-vault/tests/test-tube/range.rs
@@ -1,6 +1,6 @@
 use crate::setup::{
-    fixture_default, fixture_dex_router, init_test_contract, ADMIN_BALANCE_AMOUNT, DENOM_BASE,
-    DENOM_QUOTE, MAX_SLIPPAGE_HIGH, PERFORMANCE_FEE_DEFAULT,
+    fixture_dex_router, init_test_contract, ADMIN_BALANCE_AMOUNT, DENOM_BASE, DENOM_QUOTE,
+    MAX_SLIPPAGE_HIGH, PERFORMANCE_FEE_DEFAULT,
 };
 
 use cosmwasm_std::{coin, Coin, Decimal, Uint128};
@@ -32,7 +32,8 @@ const SWAP_SUCCESS_QUOTE_BALANCE_OFFSET: usize = 4;
 
 #[test]
 fn move_range_works() {
-    let (app, contract_address, _cl_pool_id, admin, _) = fixture_default(PERFORMANCE_FEE_DEFAULT);
+    let (app, contract_address, _dex_router, _cl_pool_id, _pools, admin, ..) =
+        fixture_dex_router(PERFORMANCE_FEE_DEFAULT);
     let wasm = Wasm::new(&app);
 
     let _before_position: PositionResponse = wasm
@@ -88,7 +89,7 @@ fn move_range_works() {
             );
             assert_eq!(
                 event.attributes[pos + SWAP_SUCCESS_QUOTE_BALANCE_OFFSET].value,
-                "1201279ubtc"
+                "1221399ubtc"
             );
         }
     }
@@ -113,13 +114,13 @@ fn move_range_works() {
         .unwrap();
     let pos_base: Coin = pos.asset0.unwrap().try_into().unwrap();
     let pos_quote: Coin = pos.asset1.unwrap().try_into().unwrap();
-    assert_eq!(pos_base, coin(762164u128, DENOM_BASE));
-    assert_eq!(pos_quote, coin(1201279u128, DENOM_QUOTE));
+    assert_eq!(pos_base, coin(774929u128, DENOM_BASE));
+    assert_eq!(pos_quote, coin(1221399u128, DENOM_QUOTE));
 }
 
 #[test]
 fn move_range_cw_dex_works() {
-    let (app, contract_address, _dex_router_addr, _vault_pool_id, _swap_pools_ids, admin, _) =
+    let (app, contract_address, _dex_router_addr, _vault_pool_id, _swap_pools_ids, admin, ..) =
         fixture_dex_router(PERFORMANCE_FEE_DEFAULT);
     let wasm = Wasm::new(&app);
 
@@ -171,7 +172,7 @@ fn move_range_cw_dex_works() {
         if let Some(pos) = pos {
             assert_eq!(
                 event.attributes[pos + SWAP_SUCCESS_BASE_BALANCE_OFFSET].value,
-                "1899998uatom"
+                "1989999uatom"
             );
             assert_eq!(
                 event.attributes[pos + SWAP_SUCCESS_QUOTE_BALANCE_OFFSET].value,
@@ -200,13 +201,13 @@ fn move_range_cw_dex_works() {
         .unwrap();
     let pos_base: Coin = pos.asset0.unwrap().try_into().unwrap();
     let pos_quote: Coin = pos.asset1.unwrap().try_into().unwrap();
-    assert_eq!(pos_base, coin(1899998u128, DENOM_BASE));
+    assert_eq!(pos_base, coin(1989999u128, DENOM_BASE));
     assert_eq!(pos_quote, coin(0u128, DENOM_QUOTE));
 }
 
 #[test]
 fn move_range_cw_dex_works_forced_swap_route() {
-    let (app, contract_address, _dex_router_addr, vault_pool_id, _swap_pools_ids, admin, _) =
+    let (app, contract_address, _dex_router_addr, vault_pool_id, _swap_pools_ids, admin, ..) =
         fixture_dex_router(PERFORMANCE_FEE_DEFAULT);
     let wasm = Wasm::new(&app);
 
@@ -266,7 +267,7 @@ fn move_range_cw_dex_works_forced_swap_route() {
         if let Some(pos) = pos {
             assert_eq!(
                 event.attributes[pos + SWAP_SUCCESS_BASE_BALANCE_OFFSET].value,
-                "1899998uatom"
+                "1989999uatom"
             );
             assert_eq!(
                 event.attributes[pos + SWAP_SUCCESS_QUOTE_BALANCE_OFFSET].value,
@@ -294,13 +295,14 @@ fn move_range_cw_dex_works_forced_swap_route() {
         .unwrap();
     let pos_base: Coin = pos.asset0.unwrap().try_into().unwrap();
     let pos_quote: Coin = pos.asset1.unwrap().try_into().unwrap();
-    assert_eq!(pos_base, coin(1899998u128, DENOM_BASE));
+    assert_eq!(pos_base, coin(1989999u128, DENOM_BASE));
     assert_eq!(pos_quote, coin(0u128, DENOM_QUOTE));
 }
 
 #[test]
 fn move_range_single_side_works() {
-    let (app, contract_address, _cl_pool_id, admin, _) = fixture_default(PERFORMANCE_FEE_DEFAULT);
+    let (app, contract_address, _dex_router_addr, _vault_pool_id, _swap_pools_ids, admin, ..) =
+        fixture_dex_router(PERFORMANCE_FEE_DEFAULT);
     let wasm = Wasm::new(&app);
 
     let response = wasm
@@ -343,7 +345,7 @@ fn move_range_single_side_works() {
         if let Some(pos) = pos {
             assert_eq!(
                 event.attributes[pos + SWAP_SUCCESS_BASE_BALANCE_OFFSET].value,
-                "1899998uatom"
+                "1989999uatom"
             );
             assert_eq!(
                 event.attributes[pos + SWAP_SUCCESS_QUOTE_BALANCE_OFFSET].value,
@@ -377,11 +379,11 @@ fn move_range_single_side_works() {
         if let Some(pos) = pos {
             assert_eq!(
                 event.attributes[pos + DO_SWAP_DEPOSIT_TOKEN_IN_OFFSET].value,
-                "1899997uatom"
+                "1989998uatom"
             );
             assert_eq!(
                 event.attributes[pos + DO_SWAP_DEPOSIT_MIN_OUT_OFFSET].value,
-                "1709997"
+                "1790998"
             );
         }
 
@@ -396,7 +398,7 @@ fn move_range_single_side_works() {
             );
             assert_eq!(
                 event.attributes[pos + SWAP_SUCCESS_QUOTE_BALANCE_OFFSET].value,
-                "1709997ubtc"
+                "1970100ubtc"
             );
         }
     }
@@ -422,7 +424,7 @@ fn move_range_single_side_works() {
     let pos_base: Coin = pos.asset0.unwrap().try_into().unwrap();
     let pos_quote: Coin = pos.asset1.unwrap().try_into().unwrap();
     assert_eq!(pos_base, coin(0u128, DENOM_BASE));
-    assert_eq!(pos_quote, coin(1709997u128, DENOM_QUOTE));
+    assert_eq!(pos_quote, coin(1970100u128, DENOM_QUOTE));
 }
 
 /*


### PR DESCRIPTION
This is part of the dex-router removal. To reduce the scope of that, I changed some of the test-tube tests to actually use the dex-router.