### PR TITLE
Move cw_vault_extension msgs to quasar-types

### DIFF
--- a/smart-contracts/osmosis/contracts/cl-vault/Cargo.toml
+++ b/smart-contracts/osmosis/contracts/cl-vault/Cargo.toml
@@ -45,7 +45,6 @@ cw2 = { workspace = true }
 num_enum = { workspace = true }
 apollo-cw-asset = { workspace = true }
 dex-router-osmosis = {workspace = true}
-cw-vault-multi-standard = {git = "https://github.com/quasar-finance/cw-vault-standard", branch ="master", features = ["lockup", "force-unlock"]}
 osmosis-test-tube = { workspace = true, optional = true }
 quasar-types = { workspace = true }
 

--- a/smart-contracts/osmosis/contracts/cl-vault/src/contract.rs
+++ b/smart-contracts/osmosis/contracts/cl-vault/src/contract.rs
@@ -5,7 +5,10 @@ use crate::helpers::prepend::prepend_claim_msg;
 use crate::instantiate::{
     handle_create_denom_reply, handle_instantiate, handle_instantiate_create_position_reply,
 };
-use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, ModifyRangeMsg, QueryMsg};
+use crate::msg::{
+    ClQueryMsg, ExecuteMsg, ExtensionExecuteMsg, ExtensionQueryMsg, InstantiateMsg, MigrateMsg,
+    ModifyRangeMsg, QueryMsg,
+};
 use crate::query::{
     query_assets_from_shares, query_dex_router, query_info, query_metadata, query_pool,
     query_position, query_total_assets, query_total_vault_token_supply, query_user_assets,
@@ -40,6 +43,7 @@ use cosmwasm_std::{
 };
 use cw2::set_contract_version;
 use cw_storage_plus::{Item, Map};
+use quasar_types::cw_vault_multi_standard::{VaultStandardExecuteMsg, VaultStandardQueryMsg};
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:cl-vault";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -63,32 +67,32 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     match msg {
-        cw_vault_multi_standard::VaultStandardExecuteMsg::AnyDeposit {
+        VaultStandardExecuteMsg::AnyDeposit {
             recipient,
             max_slippage,
             .. // asset and amount fields are not used in this implementation, they are for CW20 tokens
         } => execute_any_deposit(deps, env, info, recipient, max_slippage),
-        cw_vault_multi_standard::VaultStandardExecuteMsg::ExactDeposit { recipient } => {
+        VaultStandardExecuteMsg::ExactDeposit { recipient } => {
             execute_exact_deposit(deps, env, info, recipient)
         }
-        cw_vault_multi_standard::VaultStandardExecuteMsg::Redeem { recipient, amount } => {
+        VaultStandardExecuteMsg::Redeem { recipient, amount } => {
             prepend_claim_msg(
                 &env,
                 execute_withdraw(deps, &env, info, recipient, amount.into())?,
             )
         }
-        cw_vault_multi_standard::VaultStandardExecuteMsg::VaultExtension(vault_msg) => {
+        VaultStandardExecuteMsg::VaultExtension(vault_msg) => {
             match vault_msg {
-                crate::msg::ExtensionExecuteMsg::Admin(admin_msg) => {
+                ExtensionExecuteMsg::Admin(admin_msg) => {
                     execute_admin(deps, info, admin_msg)
                 }
-                crate::msg::ExtensionExecuteMsg::Merge(msg) => {
+                ExtensionExecuteMsg::Merge(msg) => {
                     execute_merge_position(deps, env, info, msg)
                 }
-                crate::msg::ExtensionExecuteMsg::Autocompound {} => {
+                ExtensionExecuteMsg::Autocompound {} => {
                     prepend_claim_msg(&env, execute_autocompound(deps, &env, info)?)
                 }
-                crate::msg::ExtensionExecuteMsg::ModifyRange(ModifyRangeMsg {
+                ExtensionExecuteMsg::ModifyRange(ModifyRangeMsg {
                     lower_price,
                     upper_price,
                     max_slippage,
@@ -111,11 +115,11 @@ pub fn execute(
                         claim_after,
                     )?,
                 ),
-                crate::msg::ExtensionExecuteMsg::SwapNonVaultFunds {
+                ExtensionExecuteMsg::SwapNonVaultFunds {
                     swap_operations,
                     twap_window_seconds,
                 } => execute_swap_non_vault_funds(deps, env, info, swap_operations, twap_window_seconds),
-                crate::msg::ExtensionExecuteMsg::CollectRewards {} => {
+                ExtensionExecuteMsg::CollectRewards {} => {
                     execute_collect_rewards(deps, env)
                 }
             }
@@ -126,33 +130,29 @@ pub fn execute(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
     match msg {
-        cw_vault_multi_standard::VaultStandardQueryMsg::VaultStandardInfo {} => todo!(),
-        cw_vault_multi_standard::VaultStandardQueryMsg::Info {} => {
-            Ok(to_json_binary(&query_info(deps)?)?)
+        VaultStandardQueryMsg::VaultStandardInfo {} => {
+            todo!()
         }
-        cw_vault_multi_standard::VaultStandardQueryMsg::PreviewDeposit { assets: _ } => todo!(),
-        cw_vault_multi_standard::VaultStandardQueryMsg::DepositRatio => todo!(),
-        cw_vault_multi_standard::VaultStandardQueryMsg::PreviewRedeem { amount: shares } => Ok(
-            to_json_binary(&query_assets_from_shares(deps, env, shares)?)?,
-        ),
-        cw_vault_multi_standard::VaultStandardQueryMsg::TotalAssets {} => {
+        VaultStandardQueryMsg::Info {} => Ok(to_json_binary(&query_info(deps)?)?),
+        VaultStandardQueryMsg::PreviewDeposit { assets: _ } => todo!(),
+        VaultStandardQueryMsg::DepositRatio => todo!(),
+        VaultStandardQueryMsg::PreviewRedeem { amount: shares } => Ok(to_json_binary(
+            &query_assets_from_shares(deps, env, shares)?,
+        )?),
+        VaultStandardQueryMsg::TotalAssets {} => {
             Ok(to_json_binary(&query_total_assets(deps, env)?)?)
         }
-        cw_vault_multi_standard::VaultStandardQueryMsg::TotalVaultTokenSupply {} => {
+        VaultStandardQueryMsg::TotalVaultTokenSupply {} => {
             Ok(to_json_binary(&query_total_vault_token_supply(deps)?)?)
         }
-        cw_vault_multi_standard::VaultStandardQueryMsg::ConvertToShares { amount: _ } => todo!(),
-        cw_vault_multi_standard::VaultStandardQueryMsg::ConvertToAssets { amount: shares } => Ok(
-            to_json_binary(&query_assets_from_shares(deps, env, shares)?)?,
-        ),
-        cw_vault_multi_standard::VaultStandardQueryMsg::VaultExtension(msg) => match msg {
-            crate::msg::ExtensionQueryMsg::Metadata {} => {
-                Ok(to_json_binary(&query_metadata(deps)?)?)
-            }
-            crate::msg::ExtensionQueryMsg::DexRouter {} => {
-                Ok(to_json_binary(&query_dex_router(deps)?)?)
-            }
-            crate::msg::ExtensionQueryMsg::Balances(msg) => match msg {
+        VaultStandardQueryMsg::ConvertToShares { amount: _ } => todo!(),
+        VaultStandardQueryMsg::ConvertToAssets { amount: shares } => Ok(to_json_binary(
+            &query_assets_from_shares(deps, env, shares)?,
+        )?),
+        VaultStandardQueryMsg::VaultExtension(msg) => match msg {
+            ExtensionQueryMsg::Metadata {} => Ok(to_json_binary(&query_metadata(deps)?)?),
+            ExtensionQueryMsg::DexRouter {} => Ok(to_json_binary(&query_dex_router(deps)?)?),
+            ExtensionQueryMsg::Balances(msg) => match msg {
                 crate::msg::UserBalanceQueryMsg::UserSharesBalance { user } => {
                     Ok(to_json_binary(&query_user_balance(deps, user)?)?)
                 }
@@ -160,18 +160,16 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
                     Ok(to_json_binary(&query_user_assets(deps, env, user)?)?)
                 }
             },
-            crate::msg::ExtensionQueryMsg::ConcentratedLiquidity(msg) => match msg {
-                crate::msg::ClQueryMsg::Pool {} => Ok(to_json_binary(&query_pool(deps)?)?),
-                crate::msg::ClQueryMsg::Position {} => Ok(to_json_binary(&query_position(deps)?)?),
-                crate::msg::ClQueryMsg::RangeAdmin {} => {
+            ExtensionQueryMsg::ConcentratedLiquidity(msg) => match msg {
+                ClQueryMsg::Pool {} => Ok(to_json_binary(&query_pool(deps)?)?),
+                ClQueryMsg::Position {} => Ok(to_json_binary(&query_position(deps)?)?),
+                ClQueryMsg::RangeAdmin {} => {
                     let range_admin = get_range_admin(deps)?;
                     Ok(to_json_binary(&RangeAdminResponse {
                         address: range_admin.to_string(),
                     })?)
                 }
-                crate::msg::ClQueryMsg::VerifyTickCache => {
-                    Ok(to_json_binary(&query_verify_tick_cache(deps)?)?)
-                }
+                ClQueryMsg::VerifyTickCache => Ok(to_json_binary(&query_verify_tick_cache(deps)?)?),
             },
         },
     }

--- a/smart-contracts/osmosis/contracts/cl-vault/src/msg.rs
+++ b/smart-contracts/osmosis/contracts/cl-vault/src/msg.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Decimal};
-use cw_vault_multi_standard::{VaultStandardExecuteMsg, VaultStandardQueryMsg};
 use osmosis_std::types::osmosis::poolmanager::v1beta1::SwapAmountInRoute;
+use quasar_types::cw_vault_multi_standard::{VaultStandardExecuteMsg, VaultStandardQueryMsg};
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::query::{

--- a/smart-contracts/osmosis/contracts/cl-vault/src/query.rs
+++ b/smart-contracts/osmosis/contracts/cl-vault/src/query.rs
@@ -8,8 +8,8 @@ use crate::vault::concentrated_liquidity::get_position;
 use crate::ContractError;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{coin, Coin, Decimal, Deps, Env, Uint128};
-use cw_vault_multi_standard::VaultInfoResponse;
 use osmosis_std::types::cosmos::bank::v1beta1::BankQuerier;
+use quasar_types::cw_vault_multi_standard::VaultInfoResponse;
 
 #[cw_serde]
 pub struct MetadataResponse {

--- a/smart-contracts/osmosis/contracts/cl-vault/tests/test-tube/autocompound.rs
+++ b/smart-contracts/osmosis/contracts/cl-vault/tests/test-tube/autocompound.rs
@@ -19,11 +19,11 @@ use cl_vault::query::{
 };
 use cosmwasm_std::assert_approx_eq;
 use cosmwasm_std::{Coin, Uint128};
-use cw_vault_multi_standard::VaultStandardQueryMsg::VaultExtension;
 use osmosis_std::types::cosmos::bank::v1beta1::MsgSend;
 use osmosis_std::types::cosmos::base::v1beta1::Coin as OsmoCoin;
 use osmosis_std::types::osmosis::poolmanager::v1beta1::SwapAmountInRoute;
 use osmosis_test_tube::{Account, Bank, Module, Wasm};
+use quasar_types::cw_vault_multi_standard::VaultStandardQueryMsg::VaultExtension;
 
 const DENOM_REWARD_AMOUNT: u128 = 100_000_000_000;
 const APPROX_EQ_FACTOR: &str = "0.00005";

--- a/smart-contracts/osmosis/contracts/cl-vault/tests/test-tube/initialize.rs
+++ b/smart-contracts/osmosis/contracts/cl-vault/tests/test-tube/initialize.rs
@@ -9,7 +9,6 @@ use cl_vault::{
     query::PoolResponse,
 };
 use cosmwasm_std::{Coin, Decimal};
-use cw_vault_multi_standard::VaultInfoResponse;
 use osmosis_std::types::{
     cosmos::base::v1beta1,
     osmosis::{
@@ -22,6 +21,7 @@ use osmosis_test_tube::{
     cosmrs::proto::traits::Message, Account, ConcentratedLiquidity, Module, PoolManager,
     TokenFactory, Wasm,
 };
+use quasar_types::cw_vault_multi_standard::VaultInfoResponse;
 use std::str::FromStr;
 
 #[test]

--- a/smart-contracts/osmosis/packages/quasar-types/Cargo.toml
+++ b/smart-contracts/osmosis/packages/quasar-types/Cargo.toml
@@ -4,6 +4,10 @@ name = "quasar-types"
 version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["lockup", "force-unlock"]
+lockup = []
+force-unlock = []
 
 [dependencies]
 cosmwasm-std = { workspace = true }
@@ -11,6 +15,7 @@ osmosis-std = { workspace = true }
 osmosis-std-derive = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw-storage-plus ={ workspace = true }
+cw-utils ={ workspace = true }
 schemars ={ workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_multi_standard/extensions/cw4626.rs
+++ b/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_multi_standard/extensions/cw4626.rs
@@ -1,0 +1,270 @@
+use crate::msg::{
+    ExtensionExecuteMsg, ExtensionQueryMsg, VaultInfoResponse, VaultStandardInfoResponse,
+};
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::{to_json_binary, Binary, Coin, CosmosMsg, Empty, StdResult, Uint128, WasmMsg};
+use cw20::{
+    AllAccountsResponse, AllAllowancesResponse, AllowanceResponse, BalanceResponse,
+    DownloadLogoResponse, MarketingInfoResponse, TokenInfoResponse,
+};
+use cw20::{Expiration, Logo};
+use schemars::JsonSchema;
+
+// TODO update for multi asset support
+
+/// The default ExecuteMsg variants that a vault using the Cw4626 extension must
+/// implement. This includes all of the variants from the default
+/// VaultStandardExecuteMsg, plus the variants from the CW20 standard. This enum
+/// can be extended with additional variants by defining an extension enum and
+/// then passing it as the generic argument `T` to this enum.
+#[cw_serde]
+pub enum Cw4626ExecuteMsg<T = ExtensionExecuteMsg> {
+    //--------------------------------------------------------------------------
+    // Standard CW20 ExecuteMsgs
+    //--------------------------------------------------------------------------
+    /// Transfer is a base message to move tokens to another account without
+    /// triggering actions
+    Transfer { recipient: String, amount: Uint128 },
+    /// Send is a base message to transfer tokens to a contract and trigger an
+    /// action on the receiving contract.
+    Send {
+        contract: String,
+        amount: Uint128,
+        msg: Binary,
+    },
+    /// Only with "approval" extension. Allows spender to access an additional
+    /// amount tokens from the owner's (env.sender) account. If expires is
+    /// Some(), overwrites current allowance expiration with this one.
+    IncreaseAllowance {
+        spender: String,
+        amount: Uint128,
+        expires: Option<Expiration>,
+    },
+    /// Only with "approval" extension. Lowers the spender's access of tokens
+    /// from the owner's (env.sender) account by amount. If expires is Some(),
+    /// overwrites current allowance expiration with this one.
+    DecreaseAllowance {
+        spender: String,
+        amount: Uint128,
+        expires: Option<Expiration>,
+    },
+    /// Only with "approval" extension. Transfers amount tokens from owner ->
+    /// recipient if `env.sender` has sufficient pre-approval.
+    TransferFrom {
+        owner: String,
+        recipient: String,
+        amount: Uint128,
+    },
+    /// Only with "approval" extension. Sends amount tokens from owner ->
+    /// contract if `env.sender` has sufficient pre-approval.
+    SendFrom {
+        owner: String,
+        contract: String,
+        amount: Uint128,
+        msg: Binary,
+    },
+    /// Only with the "marketing" extension. If authorized, updates marketing
+    /// metadata. Setting None/null for any of these will leave it
+    /// unchanged. Setting Some("") will clear this field on the contract
+    /// storage
+    UpdateMarketing {
+        /// A URL pointing to the project behind this token.
+        project: Option<String>,
+        /// A longer description of the token and it's utility. Designed for
+        /// tooltips or such
+        description: Option<String>,
+        /// The address (if any) who can update this data structure
+        marketing: Option<String>,
+    },
+    /// If set as the "marketing" role on the contract, upload a new URL, SVG,
+    /// or PNG for the token
+    UploadLogo(Logo),
+
+    //--------------------------------------------------------------------------
+    // Vault Standard ExecuteMsgs
+    //--------------------------------------------------------------------------
+    /// Called to deposit into the vault. Native assets are passed in the funds
+    /// parameter.
+    Deposit {
+        /// The amount of base tokens to deposit
+        amount: Uint128,
+        /// An optional field containing the recipient of the vault token. If
+        /// not set, the caller address will be used instead.
+        recipient: Option<String>,
+    },
+
+    /// Called to redeem vault tokens and receive assets back from the vault.
+    /// The native vault token must be passed in the funds parameter, unless the
+    /// lockup extension is called, in which case the vault token has already
+    /// been passed to ExecuteMsg::Unlock.
+    Redeem {
+        /// Amount of vault tokens to redeem
+        amount: Uint128,
+        /// An optional field containing which address should receive the
+        /// withdrawn base tokens. If not set, the caller address will
+        /// be used instead.
+        recipient: Option<String>,
+    },
+
+    /// Called to execute functionality of any enabled extensions.
+    VaultExtension(T),
+}
+
+impl Cw4626ExecuteMsg {
+    /// Convert a [`Cw4626ExecuteMsg`] into a [`CosmosMsg`].
+    pub fn into_cosmos_msg(self, contract_addr: String, funds: Vec<Coin>) -> StdResult<CosmosMsg> {
+        Ok(WasmMsg::Execute {
+            contract_addr,
+            msg: to_json_binary(&self)?,
+            funds,
+        }
+        .into())
+    }
+}
+
+/// The default QueryMsg variants that a vault using the Cw4626 extension must
+/// implement. This includes all of the variants from the default
+/// VaultStandardQueryMsg, plus the variants from the CW20 standard. This enum
+/// can be extended with additional variants by defining an extension enum and
+/// then passing it as the generic argument `T` to this enum.
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum Cw4626QueryMsg<T = ExtensionQueryMsg>
+where
+    T: JsonSchema,
+{
+    //--------------------------------------------------------------------------
+    // Standard CW20 QueryMsgs
+    //--------------------------------------------------------------------------
+    /// Returns the current balance of the given address, 0 if unset.
+    /// Return type: BalanceResponse.
+    #[returns(BalanceResponse)]
+    Balance { address: String },
+    /// Returns metadata on the contract - name, decimals, supply, etc.
+    /// Return type: TokenInfoResponse.
+    #[returns(TokenInfoResponse)]
+    TokenInfo {},
+    /// Only with "allowance" extension.
+    /// Returns how much spender can use from owner account, 0 if unset.
+    /// Return type: AllowanceResponse.
+    #[returns(AllowanceResponse)]
+    Allowance { owner: String, spender: String },
+    /// Only with "marketing" extension
+    /// Returns more metadata on the contract to display in the client:
+    /// - description, logo, project url, etc.
+    /// Return type: MarketingInfoResponse.
+    #[returns(MarketingInfoResponse)]
+    MarketingInfo {},
+    /// Only with "marketing" extension
+    /// Downloads the embedded logo data (if stored on chain). Errors if no logo
+    /// data stored for this contract.
+    /// Return type: DownloadLogoResponse.
+    #[returns(DownloadLogoResponse)]
+    DownloadLogo {},
+    /// Only with "enumerable" extension (and "allowances")
+    /// Returns all allowances this owner has approved. Supports pagination.
+    /// Return type: AllAllowancesResponse.
+    #[returns(AllAllowancesResponse)]
+    AllAllowances {
+        owner: String,
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+    /// Only with "enumerable" extension
+    /// Returns all accounts that have balances. Supports pagination.
+    /// Return type: AllAccountsResponse.
+    #[returns(AllAccountsResponse)]
+    AllAccounts {
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+
+    //--------------------------------------------------------------------------
+    // Vault Standard QueryMsgs
+    //--------------------------------------------------------------------------
+    /// Returns `VaultStandardInfoResponse` with information on the version of
+    /// the vault standard used as well as any enabled extensions.
+    #[returns(VaultStandardInfoResponse)]
+    VaultStandardInfo {},
+
+    /// Returns `VaultInfoResponse` representing vault requirements, lockup, &
+    /// vault token denom.
+    #[returns(VaultInfoResponse)]
+    Info {},
+
+    /// Returns `Uint128` amount of vault tokens that will be returned for the
+    /// passed in `amount` of base tokens.
+    ///
+    /// Allows an on-chain or off-chain user to simulate the effects of their
+    /// deposit at the current block, given current on-chain conditions.
+    ///
+    /// Must return as close to and no more than the exact amount of vault
+    /// tokens that would be minted in a deposit call in the same transaction.
+    /// I.e. Deposit should return the same or more vault tokens as
+    /// PreviewDeposit if called in the same transaction.
+    #[returns(Uint128)]
+    PreviewDeposit {
+        /// The amount of base tokens to preview depositing.
+        amount: Uint128,
+    },
+
+    /// Returns `Uint128` amount of base tokens that would be withdrawn in
+    /// exchange for redeeming `amount` of vault tokens.
+    ///
+    /// Allows an on-chain or off-chain user to simulate the effects of their
+    /// redeem at the current block, given current on-chain conditions.
+    ///
+    /// Must return as close to and no more than the exact amount of base tokens
+    /// that would be withdrawn in a redeem call in the same transaction.
+    #[returns(Uint128)]
+    PreviewRedeem {
+        /// The amount of vault tokens to preview redeeming.
+        amount: Uint128,
+    },
+
+    /// Returns the amount of assets managed by the vault denominated in base
+    /// tokens. Useful for display purposes, and does not have to confer the
+    /// exact amount of base tokens.
+    #[returns(Uint128)]
+    TotalAssets {},
+
+    /// Returns `Uint128` total amount of vault tokens in circulation.
+    #[returns(Uint128)]
+    TotalVaultTokenSupply {},
+
+    /// The amount of vault tokens that the vault would exchange for the amount
+    /// of assets provided, in an ideal scenario where all the conditions
+    /// are met.
+    ///
+    /// Useful for display purposes and does not have to confer the exact amount
+    /// of vault tokens returned by the vault if the passed in assets were
+    /// deposited. This calculation should not reflect the "per-user"
+    /// price-per-share, and instead should reflect the "average-user’s"
+    /// price-per-share, meaning what the average user should expect to see
+    /// when exchanging to and from.
+    #[returns(Uint128)]
+    ConvertToShares {
+        /// The amount of base tokens to convert to vault tokens.
+        amount: Uint128,
+    },
+
+    /// Returns the amount of base tokens that the Vault would exchange for
+    /// the `amount` of vault tokens provided, in an ideal scenario where all
+    /// the conditions are met.
+    ///
+    /// Useful for display purposes and does not have to confer the exact amount
+    /// of assets returned by the vault if the passed in vault tokens were
+    /// redeemed. This calculation should not reflect the "per-user"
+    /// price-per-share, and instead should reflect the "average-user’s"
+    /// price-per-share, meaning what the average user should expect to see
+    /// when exchanging to and from.
+    #[returns(Uint128)]
+    ConvertToAssets {
+        /// The amount of vault tokens to convert to base tokens.
+        amount: Uint128,
+    },
+
+    /// Handle queries of any enabled extensions.
+    #[returns(Empty)]
+    VaultExtension(T),
+}

--- a/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_multi_standard/extensions/force_unlock.rs
+++ b/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_multi_standard/extensions/force_unlock.rs
@@ -1,0 +1,57 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{to_json_binary, Coin, CosmosMsg, StdResult, Uint128, WasmMsg};
+
+use crate::cw_vault_multi_standard::msg::{ExtensionExecuteMsg, VaultStandardExecuteMsg};
+
+/// Additional ExecuteMsg variants for vaults that enable the ForceUnlock
+/// extension.
+#[cw_serde]
+pub enum ForceUnlockExecuteMsg {
+    /// Can be called by whitelisted addresses to bypass the lockup and
+    /// immediately return the base tokens. Used in the event of
+    /// liquidation. The caller must pass the native vault tokens in the funds
+    /// field.
+    ForceRedeem {
+        /// The address which should receive the withdrawn assets. If not set,
+        /// the caller address will be used instead.
+        recipient: Option<String>,
+        /// The amount of vault tokens to force redeem.
+        amount: Uint128,
+    },
+
+    /// Force withdraw from a position that is already unlocking (Unlock has
+    /// already been called).
+    ForceWithdrawUnlocking {
+        /// The ID of the unlocking position from which to force withdraw
+        lockup_id: u64,
+        /// Optional amount of base tokens to be force withdrawn.
+        /// If None is passed, the entire position will be force withdrawn.
+        amount: Option<Uint128>,
+        /// The address which should receive the withdrawn assets. If not set,
+        /// the assets will be sent to the caller.
+        recipient: Option<String>,
+    },
+
+    /// Update the whitelist of addresses that can call ForceRedeem and
+    /// ForceWithdrawUnlocking.
+    UpdateForceWithdrawWhitelist {
+        /// Addresses to add to the whitelist.
+        add_addresses: Vec<String>,
+        /// Addresses to remove from the whitelist.
+        remove_addresses: Vec<String>,
+    },
+}
+
+impl ForceUnlockExecuteMsg {
+    /// Convert a [`ForceUnlockExecuteMsg`] into a [`CosmosMsg`].
+    pub fn into_cosmos_msg(self, contract_addr: String, funds: Vec<Coin>) -> StdResult<CosmosMsg> {
+        Ok(WasmMsg::Execute {
+            contract_addr,
+            msg: to_json_binary(&VaultStandardExecuteMsg::VaultExtension(
+                ExtensionExecuteMsg::ForceUnlock(self),
+            ))?,
+            funds,
+        }
+        .into())
+    }
+}

--- a/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_multi_standard/extensions/keeper.rs
+++ b/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_multi_standard/extensions/keeper.rs
@@ -1,0 +1,77 @@
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::{to_json_binary, Addr, Coin, CosmosMsg, StdResult, WasmMsg};
+
+use crate::{ExtensionExecuteMsg, VaultStandardExecuteMsg};
+
+/// A job that can be performed by a keeper.
+#[cw_serde]
+pub struct KeeperJob {
+    /// The numeric ID of the job
+    pub id: u64,
+    /// whether only whitelisted keepers can execute the job or not
+    pub whitelist: bool,
+    /// A list of whitelisted addresses that can execute the job
+    pub whitelisted_keepers: Vec<Addr>,
+}
+
+/// Additional ExecuteMsg variants for vaults that enable the Keeper extension.
+#[cw_serde]
+pub enum KeeperExecuteMsg {
+    /// Callable by vault admin to whitelist a keeper to be able to execute a
+    /// job
+    WhitelistKeeper {
+        /// The ID of the job to whitelist the keeper for
+        job_id: u64,
+        /// The address of the keeper to whitelist
+        keeper: String,
+    },
+    /// Callable by vault admin to remove a keeper from the whitelist of a job
+    BlacklistKeeper {
+        /// The ID of the job to blacklist the keeper for
+        job_id: u64,
+        /// The address of the keeper to blacklist
+        keeper: String,
+    },
+    /// Execute a keeper job. Should only be able to be called if
+    /// [`KeeperQueryMsg::KeeperJobReady`] returns true, and only by whitelisted
+    /// keepers if the whitelist bool on the KeeperJob is set to true.
+    ExecuteJob {
+        /// The ID of the job to execute
+        job_id: u64,
+    },
+}
+
+impl KeeperExecuteMsg {
+    /// Convert a [`KeeperExecuteMsg`] into a [`CosmosMsg`].
+    pub fn into_cosmos_msg(self, contract_addr: String, funds: Vec<Coin>) -> StdResult<CosmosMsg> {
+        Ok(WasmMsg::Execute {
+            contract_addr,
+            msg: to_json_binary(&VaultStandardExecuteMsg::VaultExtension(
+                ExtensionExecuteMsg::Keeper(self),
+            ))?,
+            funds,
+        }
+        .into())
+    }
+}
+
+/// Additional QueryMsg variants for vaults that enable the Keeper extension.
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum KeeperQueryMsg {
+    /// Returns [`Vec<KeeperJob>`]
+    #[returns(Vec<KeeperJob>)]
+    KeeperJobs {},
+    /// Returns [`Vec<Addr>`]
+    #[returns(Vec<Addr>)]
+    WhitelistedKeepers {
+        /// The ID of the job to get the whitelisted keepers for
+        job_id: u64,
+    },
+    /// Returns bool, whether the keeper job can be executed or not
+    #[returns(bool)]
+    KeeperJobReady {
+        /// The ID of the job to check whether it is ready to be executed
+        job_id: u64,
+    },
+}

--- a/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_multi_standard/extensions/lockup.rs
+++ b/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_multi_standard/extensions/lockup.rs
@@ -1,0 +1,108 @@
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::{to_json_binary, Addr, Coin, CosmosMsg, StdResult, Uint128, WasmMsg};
+#[cfg(not(target_arch = "wasm32"))]
+use cw_utils::Duration;
+use cw_utils::Expiration;
+
+use crate::cw_vault_multi_standard::msg::{ExtensionExecuteMsg, VaultStandardExecuteMsg};
+
+/// Type for the unlocking position created event emitted on call to `Unlock`.
+pub const UNLOCKING_POSITION_CREATED_EVENT_TYPE: &str = "unlocking_position_created";
+/// Key for the lockup id attribute in the "unlocking position created" event
+/// that is emitted on call to `Unlock`.
+pub const UNLOCKING_POSITION_ATTR_KEY: &str = "lockup_id";
+
+/// Additional ExecuteMsg variants for vaults that enable the Lockup extension.
+#[cw_serde]
+pub enum LockupExecuteMsg {
+    /// Unlock is called to initiate unlocking a locked position held by the
+    /// vault.
+    /// The caller must pass the native vault tokens in the funds field.
+    /// Emits an event with type `UNLOCKING_POSITION_CREATED_EVENT_TYPE` with
+    /// an attribute with key `UNLOCKING_POSITION_ATTR_KEY` containing an u64
+    /// lockup_id.
+    ///
+    /// Like Redeem, this takes an amount so that the same API can be used for
+    /// CW4626 and native tokens.
+    Unlock {
+        /// The amount of vault tokens to unlock.
+        amount: Uint128,
+    },
+
+    /// EmergencyUnlock is called to initiate unlocking a locked position held
+    /// by the vault.
+    /// This call should simply unlock `amount` of vault tokens, without performing
+    /// any other side effects that might cause the transaction to fail. Such
+    /// as for example compoundning rewards for an LP position.
+    EmergencyUnlock {
+        /// The amount of vault tokens to unlock.
+        amount: Uint128,
+    },
+
+    /// Withdraw an unlocking position that has finished unlocking.
+    WithdrawUnlocked {
+        /// An optional field containing which address should receive the
+        /// withdrawn base tokens. If not set, the caller address will be
+        /// used instead.
+        recipient: Option<String>,
+        /// The ID of the expired lockup to withdraw from.
+        lockup_id: u64,
+    },
+}
+
+impl LockupExecuteMsg {
+    /// Convert a [`LockupExecuteMsg`] into a [`CosmosMsg`].
+    pub fn into_cosmos_msg(self, contract_addr: String, funds: Vec<Coin>) -> StdResult<CosmosMsg> {
+        Ok(WasmMsg::Execute {
+            contract_addr,
+            msg: to_json_binary(&VaultStandardExecuteMsg::VaultExtension(
+                ExtensionExecuteMsg::Lockup(self),
+            ))?,
+            funds,
+        }
+        .into())
+    }
+}
+
+/// Additional QueryMsg variants for vaults that enable the Lockup extension.
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum LockupQueryMsg {
+    /// Returns a `Vec<UnlockingPosition>` containing all the currently
+    /// unclaimed lockup positions for the `owner`.
+    #[returns(Vec<UnlockingPosition>)]
+    UnlockingPositions {
+        /// The address of the owner of the lockup
+        owner: String,
+        /// Return results only after this lockup_id
+        start_after: Option<u64>,
+        /// Max amount of results to return
+        limit: Option<u32>,
+    },
+
+    /// Returns an `UnlockingPosition` info about a specific lockup, by owner
+    /// and ID.
+    #[returns(UnlockingPosition)]
+    UnlockingPosition {
+        /// The ID of the lockup to query
+        lockup_id: u64,
+    },
+
+    /// Returns `cw_utils::Duration` duration of the lockup of the vault.
+    #[returns(Duration)]
+    LockupDuration {},
+}
+
+/// Info about a currenly unlocking position.
+#[cw_serde]
+pub struct UnlockingPosition {
+    /// The ID of the lockup.
+    pub id: u64,
+    /// The address of the owner of the lockup.
+    pub owner: Addr,
+    /// A `cw_utils::Expiration` containing information about when the position
+    /// completes unlocking.
+    pub release_at: Expiration,
+    /// The amount of base tokens that are being unlocked.
+    pub base_token_amount: Uint128,
+}

--- a/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_multi_standard/extensions/mod.rs
+++ b/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_multi_standard/extensions/mod.rs
@@ -1,0 +1,43 @@
+/// The lockup extension can be used to create vaults where the vault tokens are
+/// not immediately reedemable. Instead of normally calling the
+/// `VaultStandardExecuteMsg::Redeem` variant, the user has to call the `Unlock`
+/// variant on the Lockup extension `ExecuteMsg` and wait for a specified period
+/// of time before they can withdraw their base tokens via the
+/// `WithdrawUnlocked` variant.
+#[cfg(feature = "lockup")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lockup")))]
+pub mod lockup;
+
+/// The force unlock extension can be used to create a vault that also
+/// implements the `Lockup` extension, but where some whitelisted addresses are
+/// allowed to call the `ForceUnlock` variant on the extension `ExecuteMsg` and
+/// immediately unlock the vault tokens of the specified user. This is useful if
+/// the vault is used with leverage and a liquidator needs to be able to
+/// liquidate the tokens locked in the vault.
+#[cfg(feature = "force-unlock")]
+#[cfg_attr(docsrs, doc(cfg(feature = "force-unlock")))]
+pub mod force_unlock;
+
+/// The keeper extension can be used to add functionality for either whitelisted
+/// addresses or anyone to act as a "keeper" for the vault and call functions to
+/// perform jobs that need to be done to keep the vault running.
+#[cfg(feature = "keeper")]
+#[cfg_attr(docsrs, doc(cfg(feature = "keeper")))]
+pub mod keeper;
+
+/// The Cw4626 extension is the only extension provided with in this repo that
+/// does not extend the standard `ExecuteMsg` and `QueryMsg` enums with by
+/// putting its variants inside of a `VaultExtension` variant. Instead it adds
+/// more variants at the top level, namely the variants from the [CW20
+/// standard](https://github.com/CosmWasm/cw-plus/tree/main/packages/cw20) This
+/// is inspired by the [ERC-4626 standard on
+/// Ethereum](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/)
+/// and allows the vault to, instead of using a Cosmos native token as the vault
+/// token, have the vault contract be it's own vault token by also implementing
+/// the CW20 standard. This is useful if you are writing a vault on a chain that
+/// does not yet have the [TokenFactory
+/// module](https://github.com/CosmWasm/token-factory) available and can
+/// therefore not issue a Cosmos native token as the vault token.
+#[cfg(feature = "cw4626")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cw4626")))]
+pub mod cw4626;

--- a/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_multi_standard/mod.rs
+++ b/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_multi_standard/mod.rs
@@ -1,0 +1,124 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+//! # CosmWasm Vault Standard
+//!
+//! A standard interface for tokenized vaults written in CosmWasm. This repo
+//! contains a set of `ExecuteMsg` and `QueryMsg` variants that should be
+//! implemented by a vault contract that adheres to this standard.
+//!
+//! ## Vault Standard Fundamentals
+//! There are a few things to know about the vault standard:
+//! * Each vault has one specific token that is used for deposits, withdrawals
+//!   and accounting. This token is called the `base token`.
+//! * Each vault has a `vault token` that represents the users share in the
+//!   vault. The number of vault tokens the user receives should be based on the
+//!   the number of base tokens they deposit.
+//!
+//! ## How to create a vault contract that adheres to this standard
+//!
+//! To create a vault contract that adheres to the standard, all you need to do
+//! is import the [VaultStandardExecuteMsg] and [VaultStandardQueryMsg] enums
+//! and use them in the entrypoints of your contracts.
+//!
+//! The [VaultStandardExecuteMsg] and [VaultStandardQueryMsg] enums define a set
+//! of variants that should be enough to cover most vault contract use cases,
+//! and all vaults that adhere to the standard must implement all of the
+//! provided default variants. If however your use case requires additional
+//! variants, please see the section on [how to use
+//! extensions](#how-to-use-extensions).
+//!
+//! ## Description and specification of ExecuteMsg and QueryMsg variants
+//! Please refer to the documentation page for each of the enums
+//! [VaultStandardExecuteMsg] and [VaultStandardQueryMsg] for a complete
+//! description of each variant.
+//!
+//! ## How to use Extensions
+//!
+//! If the standard set of `ExecuteMsg` and `QueryMsg` variants are not enough
+//! for your use case, you can include additional ones by defining an extension.
+//! The preferred way to do this is by creating a new enum that extends the
+//! exported [VaultStandardExecuteMsg] and [VaultStandardQueryMsg] enums. For
+//! example:
+//!
+//! ```ignore
+//! pub enum MyExtensionExecuteMsg {
+//!     MyVariant1 { ... },
+//!     MyVariant2 { ... },
+//! }
+//! ```
+//! This enum can then be included in an enum with all the Extensions that your
+//! vault uses and then be passed in as the generic argument `T` to
+//! [`VaultStandardExecuteMsg<T>`]. For example:
+//!
+//! ```ignore
+//! pub enum ExtensionExecuteMsg {
+//!     MyExtension(MyExtensionExecuteMsg),
+//!     Lockup(LockupExecuteMsg),
+//! }
+//!
+//! pub type ExecuteMsg = VaultStandardExecuteMsg<ExtensionExecuteMsg>;
+//! ```
+//!
+//! Now you can use the `ExecuteMsg` enum in your contract entrypoints instead
+//! of the default [VaultStandardExecuteMsg] enum.
+//!
+//! ## Included Extensions
+//!
+//! The following extensions are included in this repo:
+//! * [Lockup](crate::extensions::lockup)
+//! * [ForceUnlock](crate::extensions::force_unlock)
+//! * [Keeper](crate::extensions::keeper)
+//! * [Cw4626](crate::extensions::cw4626)
+//!
+//! Each of these extensions are available in this repo via cargo features. To
+//! use them, you can import the crate with a feature flag like this:
+//!
+//! ```toml
+//! cw-vault-standard = { version = "0.2.0", features = ["lockup", "force_unlock"] }
+//! ```
+//!
+//! A short description of each extension can be found below.
+//!
+//! ### Lockup
+//! The lockup extension can be used to create vaults where the vault tokens are
+//! not immediately reedemable. Instead of normally calling the
+//! [`VaultStandardExecuteMsg::Redeem`] variant, the user has to call the
+//! `Unlock` variant on the Lockup extension `ExecuteMsg` and wait for a
+//! specified period of time before they can withdraw their base tokens via the
+//! `WithdrawUnlocked` variant.
+//!
+//! ### ForceUnlock
+//! The force unlock extension can be used to create a vault that also
+//! implements the `Lockup` extension, but where some whitelisted addresses are
+//! allowed to call the `ForceUnlock` variant on the extension `ExecuteMsg` and
+//! immediately unlock the vault tokens of the specified user. This is useful if
+//! the vault is used with leverage and a liquidator needs to be able to
+//! liquidate the tokens locked in the vault.
+//!
+//! ### Keeper
+//! The keeper extension can be used to add functionality for either whitelisted
+//! addresses or anyone to act as a "keeper" for the vault and call functions to
+//! perform jobs that need to be done to keep the vault running.
+//!
+//! ### Cw4626
+//! The Cw4626 extension is the only extension provided with in this repo that
+//! does not extend the default [`VaultStandardExecuteMsg`] and
+//! [`VaultStandardQueryMsg`] enums by putting its variants inside of the
+//! [`VaultStandardExecuteMsg::VaultExtension`] variant. Instead it adds more
+//! variants at the top level, namely the variants from the [CW20
+//! standard](https://github.com/CosmWasm/cw-plus/tree/main/packages/cw20). This
+//! is inspired by the [ERC-4626 standard on
+//! Ethereum](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/)
+//! and allows the vault to, instead of using a Cosmos native token as the vault
+//! token, have the vault contract be it's own vault token by also implementing
+//! the CW20 standard. This is useful if you are writing a vault on a chain that
+//! does not yet have the [TokenFactory
+//! module](https://github.com/CosmWasm/token-factory) available and can
+//! therefore not issue a Cosmos native token as the vault token.
+
+/// Module containing some pre-defined vault standard extensions.
+pub mod extensions;
+/// Module containing the vault standard ExecutMsg and QueryMsg enums, as well
+/// as QueryMsg response types.
+pub mod msg;
+
+pub use msg::*;

--- a/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_multi_standard/msg.rs
+++ b/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_multi_standard/msg.rs
@@ -1,0 +1,231 @@
+#[cfg(feature = "force-unlock")]
+use crate::cw_vault_multi_standard::extensions::force_unlock::ForceUnlockExecuteMsg;
+#[cfg(feature = "keeper")]
+use crate::cw_vault_multi_standard::extensions::keeper::{KeeperExecuteMsg, KeeperQueryMsg};
+#[cfg(feature = "lockup")]
+use crate::cw_vault_multi_standard::extensions::lockup::{LockupExecuteMsg, LockupQueryMsg};
+
+use cosmwasm_schema::{cw_serde, QueryResponses};
+#[cfg(not(target_arch = "wasm32"))]
+use cosmwasm_std::Empty;
+use cosmwasm_std::{to_json_binary, Coin, CosmosMsg, Decimal, StdResult, Uint128, WasmMsg};
+use schemars::JsonSchema;
+
+/// The default ExecuteMsg variants that all vaults must implement.
+/// This enum can be extended with additional variants by defining an extension
+/// enum and then passing it as the generic argument `T` to this enum.
+#[cw_serde]
+pub enum VaultStandardExecuteMsg<T = ExtensionExecuteMsg> {
+    /// Called to deposit an any of the assets into the vault. Assets are passed in the funds parameter.
+    /// This should functions as a deposit function that "just handles the deposit", it might swap user funds to
+    /// the ratio needed. This should support both single sided deposits aswell as unbalanced deposits
+    AnyDeposit {
+        /// The amount of tokens to deposit.
+        amount: Uint128,
+        /// the asset to deposit
+        asset: String,
+        /// The optional recipient of the vault token. If not set, the caller
+        /// address will be used instead.
+        recipient: Option<String>,
+        /// The maximum slippage allowed for swap between vault assets for deposit
+        max_slippage: Decimal,
+    },
+
+    /// Called to deposit multiple assets into the vault. The assets should be passed in the funds
+    /// parameter. The vault should either accept funds in the correct ratio and error on incorrect ratio's,
+    /// or refund and funds that are not in the correct ratio
+    ExactDeposit {
+        /// The optional recipient of the vault token. If not set, the caller
+        /// address will be used instead.
+        recipient: Option<String>,
+    },
+
+    /// Called to redeem vault tokens and receive assets back from the vault.
+    /// The native vault token must be passed in the funds parameter, unless the
+    /// lockup extension is called, in which case the vault token has already
+    /// been passed to ExecuteMsg::Unlock.
+    Redeem {
+        /// An optional field containing which address should receive the
+        /// withdrawn base tokens. If not set, the caller address will be
+        /// used instead.
+        recipient: Option<String>,
+        /// The amount of vault tokens sent to the contract. In the case that
+        /// the vault token is a Cosmos native denom, we of course have this
+        /// information in info.funds, but if the vault implements the
+        /// Cw4626 API, then we need this argument. We figured it's
+        /// better to have one API for both types of vaults, so we
+        /// require this argument.
+        amount: Uint128,
+    },
+
+    /// Called to execute functionality of any enabled extensions.
+    VaultExtension(T),
+}
+
+impl VaultStandardExecuteMsg {
+    /// Convert a [`VaultStandardExecuteMsg`] into a [`CosmosMsg`].
+    pub fn into_cosmos_msg(self, contract_addr: String, funds: Vec<Coin>) -> StdResult<CosmosMsg> {
+        Ok(WasmMsg::Execute {
+            contract_addr,
+            msg: to_json_binary(&self)?,
+            funds,
+        }
+        .into())
+    }
+}
+
+/// Contains ExecuteMsgs of all enabled extensions. To enable extensions defined
+/// outside of this crate, you can define your own `ExtensionExecuteMsg` type
+/// in your contract crate and pass it in as the generic parameter to ExecuteMsg
+#[cw_serde]
+pub enum ExtensionExecuteMsg {
+    #[cfg(feature = "keeper")]
+    Keeper(KeeperExecuteMsg),
+    #[cfg(feature = "lockup")]
+    Lockup(LockupExecuteMsg),
+    #[cfg(feature = "force-unlock")]
+    ForceUnlock(ForceUnlockExecuteMsg),
+}
+
+/// The default QueryMsg variants that all vaults must implement.
+/// This enum can be extended with additional variants by defining an extension
+/// enum and then passing it as the generic argument `T` to this enum.
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum VaultStandardQueryMsg<T = ExtensionQueryMsg>
+where
+    T: JsonSchema,
+{
+    /// Returns `VaultStandardInfoResponse` with information on the version of
+    /// the vault standard used as well as any enabled extensions.
+    #[returns(VaultStandardInfoResponse)]
+    VaultStandardInfo {},
+
+    /// Returns `VaultInfoResponse` representing vault requirements, lockup, &
+    /// vault token denom.
+    #[returns(VaultInfoResponse)]
+    Info {},
+
+    /// Returns `Uint128` amount of vault tokens that will be returned for the
+    /// passed in assets. If the vault cannot accept this set tokens,  
+    /// the query should error. This can be due to wrong ratio's, or
+    /// missing or superfluous assets
+    ///
+    /// Allows an on-chain or off-chain user to simulate the effects of their
+    /// deposit at the current block, given current on-chain conditions.
+    ///
+    /// Must return as close to and no more than the exact amount of vault
+    /// tokens that would be minted in a deposit call in the same transaction.
+    /// I.e. Deposit should return the same or more vault tokens as
+    /// PreviewDeposit if called in the same transaction.
+    #[returns(Uint128)]
+    PreviewDeposit {
+        /// The of assets to deposit.
+        assets: Vec<Coin>,
+    },
+
+    /// Returns the ratio in which the underlying assets should be deposited.
+    /// If no ratio is applicable, should return None. Ratios are expressed
+    /// as a Vec<Coin>. This should be interpreted as a deposit should be
+    /// some multiplicative of the returned vec.
+    ///
+    /// A vault does not have to guarantee that this ratio is stable.
+    #[returns(Vec<Coin>)]
+    DepositRatio,
+
+    /// Returns `Uint128` amount of base tokens that would be withdrawn in
+    /// exchange for redeeming `amount` of vault tokens.
+    ///
+    /// Allows an on-chain or off-chain user to simulate the effects of their
+    /// redeem at the current block, given current on-chain conditions.
+    ///
+    /// Must return as close to and no more than the exact amount of base tokens
+    /// that would be withdrawn in a redeem call in the same transaction.
+    #[returns(Uint128)]
+    PreviewRedeem {
+        /// The amount of vault tokens to preview redeeming.
+        amount: Uint128,
+    },
+
+    /// Returns the amount of assets managed by the vault denominated in underlying
+    /// tokens. Useful for display purposes.
+    #[returns(Vec<Coin>)]
+    TotalAssets {},
+
+    /// Returns `Uint128` total amount of vault tokens in circulation.
+    #[returns(Uint128)]
+    TotalVaultTokenSupply {},
+
+    /// The amount of vault tokens that the vault would exchange for the amount
+    /// of assets provided, in an ideal scenario where all the conditions
+    /// are met.
+    ///
+    /// Useful for display purposes and does not have to confer the exact amount
+    /// of vault tokens returned by the vault if the passed in assets were
+    /// deposited. This calculation should not reflect the "per-user"
+    /// price-per-share, and instead should reflect the "average-user’s"
+    /// price-per-share, meaning what the average user should expect to see
+    /// when exchanging to and from.
+    #[returns(Uint128)]
+    ConvertToShares {
+        /// The amount of base tokens to convert to vault tokens.
+        amount: Vec<Coin>,
+    },
+
+    /// Returns the amount of base tokens that the Vault would exchange for
+    /// the `amount` of vault tokens provided, in an ideal scenario where all
+    /// the conditions are met.
+    ///
+    /// Useful for display purposes and does not have to confer the exact amount
+    /// of assets returned by the vault if the passed in vault tokens were
+    /// redeemed. This calculation should not reflect the "per-user"
+    /// price-per-share, and instead should reflect the "average-user’s"
+    /// price-per-share, meaning what the average user should expect to see
+    /// when exchanging to and from.
+    #[returns(Uint128)]
+    ConvertToAssets {
+        /// The amount of vault tokens to convert to base tokens.
+        amount: Uint128,
+    },
+
+    /// Handle queries of any enabled extensions.
+    #[returns(Empty)]
+    VaultExtension(T),
+}
+
+/// Contains QueryMsgs of all enabled extensions. To enable extensions defined
+/// outside of this crate, you can define your own `ExtensionQueryMsg` type
+/// in your contract crate and pass it in as the generic parameter to QueryMsg
+#[cw_serde]
+pub enum ExtensionQueryMsg {
+    #[cfg(feature = "keeper")]
+    Keeper(KeeperQueryMsg),
+    #[cfg(feature = "lockup")]
+    Lockup(LockupQueryMsg),
+}
+
+/// Struct returned from QueryMsg::VaultStandardInfo with information about the
+/// used version of the vault standard and any extensions used.
+///
+/// This struct should be stored as an Item under the `vault_standard_info` key,
+/// so that other contracts can do a RawQuery and read it directly from storage
+/// instead of needing to do a costly SmartQuery.
+#[cw_serde]
+pub struct VaultStandardInfoResponse {
+    /// The version of the vault standard used. A number, e.g. 1, 2, etc.
+    pub version: u16,
+    /// A list of vault standard extensions used by the vault.
+    /// E.g. ["lockup", "keeper"]
+    pub extensions: Vec<String>,
+}
+
+/// Returned by QueryMsg::Info and contains information about this vault
+#[cw_serde]
+pub struct VaultInfoResponse {
+    /// The tokens used by the vault and accepted for deposits, withdrawals. the value is a denom if it is a native token and a
+    /// contract address if it is a cw20 token. The value expression of internal accounting is left up to the vault.
+    pub tokens: Vec<String>,
+    /// Vault token. The denom if it is a native token and the contract address
+    /// if it is a cw20 token.
+    pub vault_token: String,
+}

--- a/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_standard/extensions/cw4626.rs
+++ b/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_standard/extensions/cw4626.rs
@@ -1,0 +1,268 @@
+use crate::msg::{
+    ExtensionExecuteMsg, ExtensionQueryMsg, VaultInfoResponse, VaultStandardInfoResponse,
+};
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::{to_json_binary, Binary, Coin, CosmosMsg, Empty, StdResult, Uint128, WasmMsg};
+use cw20::{
+    AllAccountsResponse, AllAllowancesResponse, AllowanceResponse, BalanceResponse,
+    DownloadLogoResponse, MarketingInfoResponse, TokenInfoResponse,
+};
+use cw20::{Expiration, Logo};
+use schemars::JsonSchema;
+
+/// The default ExecuteMsg variants that a vault using the Cw4626 extension must
+/// implement. This includes all of the variants from the default
+/// VaultStandardExecuteMsg, plus the variants from the CW20 standard. This enum
+/// can be extended with additional variants by defining an extension enum and
+/// then passing it as the generic argument `T` to this enum.
+#[cw_serde]
+pub enum Cw4626ExecuteMsg<T = ExtensionExecuteMsg> {
+    //--------------------------------------------------------------------------
+    // Standard CW20 ExecuteMsgs
+    //--------------------------------------------------------------------------
+    /// Transfer is a base message to move tokens to another account without
+    /// triggering actions
+    Transfer { recipient: String, amount: Uint128 },
+    /// Send is a base message to transfer tokens to a contract and trigger an
+    /// action on the receiving contract.
+    Send {
+        contract: String,
+        amount: Uint128,
+        msg: Binary,
+    },
+    /// Only with "approval" extension. Allows spender to access an additional
+    /// amount tokens from the owner's (env.sender) account. If expires is
+    /// Some(), overwrites current allowance expiration with this one.
+    IncreaseAllowance {
+        spender: String,
+        amount: Uint128,
+        expires: Option<Expiration>,
+    },
+    /// Only with "approval" extension. Lowers the spender's access of tokens
+    /// from the owner's (env.sender) account by amount. If expires is Some(),
+    /// overwrites current allowance expiration with this one.
+    DecreaseAllowance {
+        spender: String,
+        amount: Uint128,
+        expires: Option<Expiration>,
+    },
+    /// Only with "approval" extension. Transfers amount tokens from owner ->
+    /// recipient if `env.sender` has sufficient pre-approval.
+    TransferFrom {
+        owner: String,
+        recipient: String,
+        amount: Uint128,
+    },
+    /// Only with "approval" extension. Sends amount tokens from owner ->
+    /// contract if `env.sender` has sufficient pre-approval.
+    SendFrom {
+        owner: String,
+        contract: String,
+        amount: Uint128,
+        msg: Binary,
+    },
+    /// Only with the "marketing" extension. If authorized, updates marketing
+    /// metadata. Setting None/null for any of these will leave it
+    /// unchanged. Setting Some("") will clear this field on the contract
+    /// storage
+    UpdateMarketing {
+        /// A URL pointing to the project behind this token.
+        project: Option<String>,
+        /// A longer description of the token and it's utility. Designed for
+        /// tooltips or such
+        description: Option<String>,
+        /// The address (if any) who can update this data structure
+        marketing: Option<String>,
+    },
+    /// If set as the "marketing" role on the contract, upload a new URL, SVG,
+    /// or PNG for the token
+    UploadLogo(Logo),
+
+    //--------------------------------------------------------------------------
+    // Vault Standard ExecuteMsgs
+    //--------------------------------------------------------------------------
+    /// Called to deposit into the vault. Native assets are passed in the funds
+    /// parameter.
+    Deposit {
+        /// The amount of base tokens to deposit
+        amount: Uint128,
+        /// An optional field containing the recipient of the vault token. If
+        /// not set, the caller address will be used instead.
+        recipient: Option<String>,
+    },
+
+    /// Called to redeem vault tokens and receive assets back from the vault.
+    /// The native vault token must be passed in the funds parameter, unless the
+    /// lockup extension is called, in which case the vault token has already
+    /// been passed to ExecuteMsg::Unlock.
+    Redeem {
+        /// Amount of vault tokens to redeem
+        amount: Uint128,
+        /// An optional field containing which address should receive the
+        /// withdrawn base tokens. If not set, the caller address will
+        /// be used instead.
+        recipient: Option<String>,
+    },
+
+    /// Called to execute functionality of any enabled extensions.
+    VaultExtension(T),
+}
+
+impl Cw4626ExecuteMsg {
+    /// Convert a [`Cw4626ExecuteMsg`] into a [`CosmosMsg`].
+    pub fn into_cosmos_msg(self, contract_addr: String, funds: Vec<Coin>) -> StdResult<CosmosMsg> {
+        Ok(WasmMsg::Execute {
+            contract_addr,
+            msg: to_json_binary(&self)?,
+            funds,
+        }
+        .into())
+    }
+}
+
+/// The default QueryMsg variants that a vault using the Cw4626 extension must
+/// implement. This includes all of the variants from the default
+/// VaultStandardQueryMsg, plus the variants from the CW20 standard. This enum
+/// can be extended with additional variants by defining an extension enum and
+/// then passing it as the generic argument `T` to this enum.
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum Cw4626QueryMsg<T = ExtensionQueryMsg>
+where
+    T: JsonSchema,
+{
+    //--------------------------------------------------------------------------
+    // Standard CW20 QueryMsgs
+    //--------------------------------------------------------------------------
+    /// Returns the current balance of the given address, 0 if unset.
+    /// Return type: BalanceResponse.
+    #[returns(BalanceResponse)]
+    Balance { address: String },
+    /// Returns metadata on the contract - name, decimals, supply, etc.
+    /// Return type: TokenInfoResponse.
+    #[returns(TokenInfoResponse)]
+    TokenInfo {},
+    /// Only with "allowance" extension.
+    /// Returns how much spender can use from owner account, 0 if unset.
+    /// Return type: AllowanceResponse.
+    #[returns(AllowanceResponse)]
+    Allowance { owner: String, spender: String },
+    /// Only with "marketing" extension
+    /// Returns more metadata on the contract to display in the client:
+    /// - description, logo, project url, etc.
+    /// Return type: MarketingInfoResponse.
+    #[returns(MarketingInfoResponse)]
+    MarketingInfo {},
+    /// Only with "marketing" extension
+    /// Downloads the embedded logo data (if stored on chain). Errors if no logo
+    /// data stored for this contract.
+    /// Return type: DownloadLogoResponse.
+    #[returns(DownloadLogoResponse)]
+    DownloadLogo {},
+    /// Only with "enumerable" extension (and "allowances")
+    /// Returns all allowances this owner has approved. Supports pagination.
+    /// Return type: AllAllowancesResponse.
+    #[returns(AllAllowancesResponse)]
+    AllAllowances {
+        owner: String,
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+    /// Only with "enumerable" extension
+    /// Returns all accounts that have balances. Supports pagination.
+    /// Return type: AllAccountsResponse.
+    #[returns(AllAccountsResponse)]
+    AllAccounts {
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+
+    //--------------------------------------------------------------------------
+    // Vault Standard QueryMsgs
+    //--------------------------------------------------------------------------
+    /// Returns `VaultStandardInfoResponse` with information on the version of
+    /// the vault standard used as well as any enabled extensions.
+    #[returns(VaultStandardInfoResponse)]
+    VaultStandardInfo {},
+
+    /// Returns `VaultInfoResponse` representing vault requirements, lockup, &
+    /// vault token denom.
+    #[returns(VaultInfoResponse)]
+    Info {},
+
+    /// Returns `Uint128` amount of vault tokens that will be returned for the
+    /// passed in `amount` of base tokens.
+    ///
+    /// Allows an on-chain or off-chain user to simulate the effects of their
+    /// deposit at the current block, given current on-chain conditions.
+    ///
+    /// Must return as close to and no more than the exact amount of vault
+    /// tokens that would be minted in a deposit call in the same transaction.
+    /// I.e. Deposit should return the same or more vault tokens as
+    /// PreviewDeposit if called in the same transaction.
+    #[returns(Uint128)]
+    PreviewDeposit {
+        /// The amount of base tokens to preview depositing.
+        amount: Uint128,
+    },
+
+    /// Returns `Uint128` amount of base tokens that would be withdrawn in
+    /// exchange for redeeming `amount` of vault tokens.
+    ///
+    /// Allows an on-chain or off-chain user to simulate the effects of their
+    /// redeem at the current block, given current on-chain conditions.
+    ///
+    /// Must return as close to and no more than the exact amount of base tokens
+    /// that would be withdrawn in a redeem call in the same transaction.
+    #[returns(Uint128)]
+    PreviewRedeem {
+        /// The amount of vault tokens to preview redeeming.
+        amount: Uint128,
+    },
+
+    /// Returns the amount of assets managed by the vault denominated in base
+    /// tokens. Useful for display purposes, and does not have to confer the
+    /// exact amount of base tokens.
+    #[returns(Uint128)]
+    TotalAssets {},
+
+    /// Returns `Uint128` total amount of vault tokens in circulation.
+    #[returns(Uint128)]
+    TotalVaultTokenSupply {},
+
+    /// The amount of vault tokens that the vault would exchange for the amount
+    /// of assets provided, in an ideal scenario where all the conditions
+    /// are met.
+    ///
+    /// Useful for display purposes and does not have to confer the exact amount
+    /// of vault tokens returned by the vault if the passed in assets were
+    /// deposited. This calculation should not reflect the "per-user"
+    /// price-per-share, and instead should reflect the "average-user’s"
+    /// price-per-share, meaning what the average user should expect to see
+    /// when exchanging to and from.
+    #[returns(Uint128)]
+    ConvertToShares {
+        /// The amount of base tokens to convert to vault tokens.
+        amount: Uint128,
+    },
+
+    /// Returns the amount of base tokens that the Vault would exchange for
+    /// the `amount` of vault tokens provided, in an ideal scenario where all
+    /// the conditions are met.
+    ///
+    /// Useful for display purposes and does not have to confer the exact amount
+    /// of assets returned by the vault if the passed in vault tokens were
+    /// redeemed. This calculation should not reflect the "per-user"
+    /// price-per-share, and instead should reflect the "average-user’s"
+    /// price-per-share, meaning what the average user should expect to see
+    /// when exchanging to and from.
+    #[returns(Uint128)]
+    ConvertToAssets {
+        /// The amount of vault tokens to convert to base tokens.
+        amount: Uint128,
+    },
+
+    /// Handle queries of any enabled extensions.
+    #[returns(Empty)]
+    VaultExtension(T),
+}

--- a/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_standard/extensions/force_unlock.rs
+++ b/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_standard/extensions/force_unlock.rs
@@ -1,0 +1,57 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{to_json_binary, Coin, CosmosMsg, StdResult, Uint128, WasmMsg};
+
+use crate::cw_vault_standard::msg::{ExtensionExecuteMsg, VaultStandardExecuteMsg};
+
+/// Additional ExecuteMsg variants for vaults that enable the ForceUnlock
+/// extension.
+#[cw_serde]
+pub enum ForceUnlockExecuteMsg {
+    /// Can be called by whitelisted addresses to bypass the lockup and
+    /// immediately return the base tokens. Used in the event of
+    /// liquidation. The caller must pass the native vault tokens in the funds
+    /// field.
+    ForceRedeem {
+        /// The address which should receive the withdrawn assets. If not set,
+        /// the caller address will be used instead.
+        recipient: Option<String>,
+        /// The amount of vault tokens to force redeem.
+        amount: Uint128,
+    },
+
+    /// Force withdraw from a position that is already unlocking (Unlock has
+    /// already been called).
+    ForceWithdrawUnlocking {
+        /// The ID of the unlocking position from which to force withdraw
+        lockup_id: u64,
+        /// Optional amount of base tokens to be force withdrawn.
+        /// If None is passed, the entire position will be force withdrawn.
+        amount: Option<Uint128>,
+        /// The address which should receive the withdrawn assets. If not set,
+        /// the assets will be sent to the caller.
+        recipient: Option<String>,
+    },
+
+    /// Update the whitelist of addresses that can call ForceRedeem and
+    /// ForceWithdrawUnlocking.
+    UpdateForceWithdrawWhitelist {
+        /// Addresses to add to the whitelist.
+        add_addresses: Vec<String>,
+        /// Addresses to remove from the whitelist.
+        remove_addresses: Vec<String>,
+    },
+}
+
+impl ForceUnlockExecuteMsg {
+    /// Convert a [`ForceUnlockExecuteMsg`] into a [`CosmosMsg`].
+    pub fn into_cosmos_msg(self, contract_addr: String, funds: Vec<Coin>) -> StdResult<CosmosMsg> {
+        Ok(WasmMsg::Execute {
+            contract_addr,
+            msg: to_json_binary(&VaultStandardExecuteMsg::VaultExtension(
+                ExtensionExecuteMsg::ForceUnlock(self),
+            ))?,
+            funds,
+        }
+        .into())
+    }
+}

--- a/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_standard/extensions/keeper.rs
+++ b/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_standard/extensions/keeper.rs
@@ -1,0 +1,77 @@
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::{to_json_binary, Addr, Coin, CosmosMsg, StdResult, WasmMsg};
+
+use crate::{ExtensionExecuteMsg, VaultStandardExecuteMsg};
+
+/// A job that can be performed by a keeper.
+#[cw_serde]
+pub struct KeeperJob {
+    /// The numeric ID of the job
+    pub id: u64,
+    /// whether only whitelisted keepers can execute the job or not
+    pub whitelist: bool,
+    /// A list of whitelisted addresses that can execute the job
+    pub whitelisted_keepers: Vec<Addr>,
+}
+
+/// Additional ExecuteMsg variants for vaults that enable the Keeper extension.
+#[cw_serde]
+pub enum KeeperExecuteMsg {
+    /// Callable by vault admin to whitelist a keeper to be able to execute a
+    /// job
+    WhitelistKeeper {
+        /// The ID of the job to whitelist the keeper for
+        job_id: u64,
+        /// The address of the keeper to whitelist
+        keeper: String,
+    },
+    /// Callable by vault admin to remove a keeper from the whitelist of a job
+    BlacklistKeeper {
+        /// The ID of the job to blacklist the keeper for
+        job_id: u64,
+        /// The address of the keeper to blacklist
+        keeper: String,
+    },
+    /// Execute a keeper job. Should only be able to be called if
+    /// [`KeeperQueryMsg::KeeperJobReady`] returns true, and only by whitelisted
+    /// keepers if the whitelist bool on the KeeperJob is set to true.
+    ExecuteJob {
+        /// The ID of the job to execute
+        job_id: u64,
+    },
+}
+
+impl KeeperExecuteMsg {
+    /// Convert a [`KeeperExecuteMsg`] into a [`CosmosMsg`].
+    pub fn into_cosmos_msg(self, contract_addr: String, funds: Vec<Coin>) -> StdResult<CosmosMsg> {
+        Ok(WasmMsg::Execute {
+            contract_addr,
+            msg: to_json_binaryinary(&VaultStandardExecuteMsg::VaultExtension(
+                ExtensionExecuteMsg::Keeper(self),
+            ))?,
+            funds,
+        }
+        .into())
+    }
+}
+
+/// Additional QueryMsg variants for vaults that enable the Keeper extension.
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum KeeperQueryMsg {
+    /// Returns [`Vec<KeeperJob>`]
+    #[returns(Vec<KeeperJob>)]
+    KeeperJobs {},
+    /// Returns [`Vec<Addr>`]
+    #[returns(Vec<Addr>)]
+    WhitelistedKeepers {
+        /// The ID of the job to get the whitelisted keepers for
+        job_id: u64,
+    },
+    /// Returns bool, whether the keeper job can be executed or not
+    #[returns(bool)]
+    KeeperJobReady {
+        /// The ID of the job to check whether it is ready to be executed
+        job_id: u64,
+    },
+}

--- a/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_standard/extensions/lockup.rs
+++ b/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_standard/extensions/lockup.rs
@@ -1,0 +1,108 @@
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::{to_json_binary, Addr, Coin, CosmosMsg, StdResult, Uint128, WasmMsg};
+#[cfg(not(target_arch = "wasm32"))]
+use cw_utils::Duration;
+use cw_utils::Expiration;
+
+use crate::cw_vault_standard::msg::{ExtensionExecuteMsg, VaultStandardExecuteMsg};
+
+/// Type for the unlocking position created event emitted on call to `Unlock`.
+pub const UNLOCKING_POSITION_CREATED_EVENT_TYPE: &str = "unlocking_position_created";
+/// Key for the lockup id attribute in the "unlocking position created" event
+/// that is emitted on call to `Unlock`.
+pub const UNLOCKING_POSITION_ATTR_KEY: &str = "lockup_id";
+
+/// Additional ExecuteMsg variants for vaults that enable the Lockup extension.
+#[cw_serde]
+pub enum LockupExecuteMsg {
+    /// Unlock is called to initiate unlocking a locked position held by the
+    /// vault.
+    /// The caller must pass the native vault tokens in the funds field.
+    /// Emits an event with type `UNLOCKING_POSITION_CREATED_EVENT_TYPE` with
+    /// an attribute with key `UNLOCKING_POSITION_ATTR_KEY` containing an u64
+    /// lockup_id.
+    ///
+    /// Like Redeem, this takes an amount so that the same API can be used for
+    /// CW4626 and native tokens.
+    Unlock {
+        /// The amount of vault tokens to unlock.
+        amount: Uint128,
+    },
+
+    /// EmergencyUnlock is called to initiate unlocking a locked position held
+    /// by the vault.
+    /// This call should simply unlock `amount` of vault tokens, without performing
+    /// any other side effects that might cause the transaction to fail. Such
+    /// as for example compoundning rewards for an LP position.
+    EmergencyUnlock {
+        /// The amount of vault tokens to unlock.
+        amount: Uint128,
+    },
+
+    /// Withdraw an unlocking position that has finished unlocking.
+    WithdrawUnlocked {
+        /// An optional field containing which address should receive the
+        /// withdrawn base tokens. If not set, the caller address will be
+        /// used instead.
+        recipient: Option<String>,
+        /// The ID of the expired lockup to withdraw from.
+        lockup_id: u64,
+    },
+}
+
+impl LockupExecuteMsg {
+    /// Convert a [`LockupExecuteMsg`] into a [`CosmosMsg`].
+    pub fn into_cosmos_msg(self, contract_addr: String, funds: Vec<Coin>) -> StdResult<CosmosMsg> {
+        Ok(WasmMsg::Execute {
+            contract_addr,
+            msg: to_json_binary(&VaultStandardExecuteMsg::VaultExtension(
+                ExtensionExecuteMsg::Lockup(self),
+            ))?,
+            funds,
+        }
+        .into())
+    }
+}
+
+/// Additional QueryMsg variants for vaults that enable the Lockup extension.
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum LockupQueryMsg {
+    /// Returns a `Vec<UnlockingPosition>` containing all the currently
+    /// unclaimed lockup positions for the `owner`.
+    #[returns(Vec<UnlockingPosition>)]
+    UnlockingPositions {
+        /// The address of the owner of the lockup
+        owner: String,
+        /// Return results only after this lockup_id
+        start_after: Option<u64>,
+        /// Max amount of results to return
+        limit: Option<u32>,
+    },
+
+    /// Returns an `UnlockingPosition` info about a specific lockup, by owner
+    /// and ID.
+    #[returns(UnlockingPosition)]
+    UnlockingPosition {
+        /// The ID of the lockup to query
+        lockup_id: u64,
+    },
+
+    /// Returns `cw_utils::Duration` duration of the lockup of the vault.
+    #[returns(Duration)]
+    LockupDuration {},
+}
+
+/// Info about a currenly unlocking position.
+#[cw_serde]
+pub struct UnlockingPosition {
+    /// The ID of the lockup.
+    pub id: u64,
+    /// The address of the owner of the lockup.
+    pub owner: Addr,
+    /// A `cw_utils::Expiration` containing information about when the position
+    /// completes unlocking.
+    pub release_at: Expiration,
+    /// The amount of base tokens that are being unlocked.
+    pub base_token_amount: Uint128,
+}

--- a/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_standard/extensions/mod.rs
+++ b/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_standard/extensions/mod.rs
@@ -1,0 +1,43 @@
+/// The lockup extension can be used to create vaults where the vault tokens are
+/// not immediately reedemable. Instead of normally calling the
+/// `VaultStandardExecuteMsg::Redeem` variant, the user has to call the `Unlock`
+/// variant on the Lockup extension `ExecuteMsg` and wait for a specified period
+/// of time before they can withdraw their base tokens via the
+/// `WithdrawUnlocked` variant.
+#[cfg(feature = "lockup")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lockup")))]
+pub mod lockup;
+
+/// The force unlock extension can be used to create a vault that also
+/// implements the `Lockup` extension, but where some whitelisted addresses are
+/// allowed to call the `ForceUnlock` variant on the extension `ExecuteMsg` and
+/// immediately unlock the vault tokens of the specified user. This is useful if
+/// the vault is used with leverage and a liquidator needs to be able to
+/// liquidate the tokens locked in the vault.
+#[cfg(feature = "force-unlock")]
+#[cfg_attr(docsrs, doc(cfg(feature = "force-unlock")))]
+pub mod force_unlock;
+
+/// The keeper extension can be used to add functionality for either whitelisted
+/// addresses or anyone to act as a "keeper" for the vault and call functions to
+/// perform jobs that need to be done to keep the vault running.
+#[cfg(feature = "keeper")]
+#[cfg_attr(docsrs, doc(cfg(feature = "keeper")))]
+pub mod keeper;
+
+/// The Cw4626 extension is the only extension provided with in this repo that
+/// does not extend the standard `ExecuteMsg` and `QueryMsg` enums with by
+/// putting its variants inside of a `VaultExtension` variant. Instead it adds
+/// more variants at the top level, namely the variants from the [CW20
+/// standard](https://github.com/CosmWasm/cw-plus/tree/main/packages/cw20) This
+/// is inspired by the [ERC-4626 standard on
+/// Ethereum](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/)
+/// and allows the vault to, instead of using a Cosmos native token as the vault
+/// token, have the vault contract be it's own vault token by also implementing
+/// the CW20 standard. This is useful if you are writing a vault on a chain that
+/// does not yet have the [TokenFactory
+/// module](https://github.com/CosmWasm/token-factory) available and can
+/// therefore not issue a Cosmos native token as the vault token.
+#[cfg(feature = "cw4626")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cw4626")))]
+pub mod cw4626;

--- a/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_standard/mod.rs
+++ b/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_standard/mod.rs
@@ -1,0 +1,124 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+//! # CosmWasm Vault Standard
+//!
+//! A standard interface for tokenized vaults written in CosmWasm. This repo
+//! contains a set of `ExecuteMsg` and `QueryMsg` variants that should be
+//! implemented by a vault contract that adheres to this standard.
+//!
+//! ## Vault Standard Fundamentals
+//! There are a few things to know about the vault standard:
+//! * Each vault has one specific token that is used for deposits, withdrawals
+//!   and accounting. This token is called the `base token`.
+//! * Each vault has a `vault token` that represents the users share in the
+//!   vault. The number of vault tokens the user receives should be based on the
+//!   the number of base tokens they deposit.
+//!
+//! ## How to create a vault contract that adheres to this standard
+//!
+//! To create a vault contract that adheres to the standard, all you need to do
+//! is import the [VaultStandardExecuteMsg] and [VaultStandardQueryMsg] enums
+//! and use them in the entrypoints of your contracts.
+//!
+//! The [VaultStandardExecuteMsg] and [VaultStandardQueryMsg] enums define a set
+//! of variants that should be enough to cover most vault contract use cases,
+//! and all vaults that adhere to the standard must implement all of the
+//! provided default variants. If however your use case requires additional
+//! variants, please see the section on [how to use
+//! extensions](#how-to-use-extensions).
+//!
+//! ## Description and specification of ExecuteMsg and QueryMsg variants
+//! Please refer to the documentation page for each of the enums
+//! [VaultStandardExecuteMsg] and [VaultStandardQueryMsg] for a complete
+//! description of each variant.
+//!
+//! ## How to use Extensions
+//!
+//! If the standard set of `ExecuteMsg` and `QueryMsg` variants are not enough
+//! for your use case, you can include additional ones by defining an extension.
+//! The preferred way to do this is by creating a new enum that extends the
+//! exported [VaultStandardExecuteMsg] and [VaultStandardQueryMsg] enums. For
+//! example:
+//!
+//! ```ignore
+//! pub enum MyExtensionExecuteMsg {
+//!     MyVariant1 { ... },
+//!     MyVariant2 { ... },
+//! }
+//! ```
+//! This enum can then be included in an enum with all the Extensions that your
+//! vault uses and then be passed in as the generic argument `T` to
+//! [`VaultStandardExecuteMsg<T>`]. For example:
+//!
+//! ```ignore
+//! pub enum ExtensionExecuteMsg {
+//!     MyExtension(MyExtensionExecuteMsg),
+//!     Lockup(LockupExecuteMsg),
+//! }
+//!
+//! pub type ExecuteMsg = VaultStandardExecuteMsg<ExtensionExecuteMsg>;
+//! ```
+//!
+//! Now you can use the `ExecuteMsg` enum in your contract entrypoints instead
+//! of the default [VaultStandardExecuteMsg] enum.
+//!
+//! ## Included Extensions
+//!
+//! The following extensions are included in this repo:
+//! * [Lockup](crate::extensions::lockup)
+//! * [ForceUnlock](crate::extensions::force_unlock)
+//! * [Keeper](crate::extensions::keeper)
+//! * [Cw4626](crate::extensions::cw4626)
+//!
+//! Each of these extensions are available in this repo via cargo features. To
+//! use them, you can import the crate with a feature flag like this:
+//!
+//! ```toml
+//! cw-vault-standard = { version = "0.2.0", features = ["lockup", "force_unlock"] }
+//! ```
+//!
+//! A short description of each extension can be found below.
+//!
+//! ### Lockup
+//! The lockup extension can be used to create vaults where the vault tokens are
+//! not immediately reedemable. Instead of normally calling the
+//! [`VaultStandardExecuteMsg::Redeem`] variant, the user has to call the
+//! `Unlock` variant on the Lockup extension `ExecuteMsg` and wait for a
+//! specified period of time before they can withdraw their base tokens via the
+//! `WithdrawUnlocked` variant.
+//!
+//! ### ForceUnlock
+//! The force unlock extension can be used to create a vault that also
+//! implements the `Lockup` extension, but where some whitelisted addresses are
+//! allowed to call the `ForceUnlock` variant on the extension `ExecuteMsg` and
+//! immediately unlock the vault tokens of the specified user. This is useful if
+//! the vault is used with leverage and a liquidator needs to be able to
+//! liquidate the tokens locked in the vault.
+//!
+//! ### Keeper
+//! The keeper extension can be used to add functionality for either whitelisted
+//! addresses or anyone to act as a "keeper" for the vault and call functions to
+//! perform jobs that need to be done to keep the vault running.
+//!
+//! ### Cw4626
+//! The Cw4626 extension is the only extension provided with in this repo that
+//! does not extend the default [`VaultStandardExecuteMsg`] and
+//! [`VaultStandardQueryMsg`] enums by putting its variants inside of the
+//! [`VaultStandardExecuteMsg::VaultExtension`] variant. Instead it adds more
+//! variants at the top level, namely the variants from the [CW20
+//! standard](https://github.com/CosmWasm/cw-plus/tree/main/packages/cw20). This
+//! is inspired by the [ERC-4626 standard on
+//! Ethereum](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/)
+//! and allows the vault to, instead of using a Cosmos native token as the vault
+//! token, have the vault contract be it's own vault token by also implementing
+//! the CW20 standard. This is useful if you are writing a vault on a chain that
+//! does not yet have the [TokenFactory
+//! module](https://github.com/CosmWasm/token-factory) available and can
+//! therefore not issue a Cosmos native token as the vault token.
+
+/// Module containing some pre-defined vault standard extensions.
+pub mod extensions;
+/// Module containing the vault standard ExecutMsg and QueryMsg enums, as well
+/// as QueryMsg response types.
+pub mod msg;
+
+pub use msg::*;

--- a/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_standard/msg.rs
+++ b/smart-contracts/osmosis/packages/quasar-types/src/cw_vault_standard/msg.rs
@@ -1,0 +1,208 @@
+#[cfg(feature = "force-unlock")]
+use crate::cw_vault_standard::extensions::force_unlock::ForceUnlockExecuteMsg;
+#[cfg(feature = "keeper")]
+use crate::cw_vault_standard::extensions::keeper::{KeeperExecuteMsg, KeeperQueryMsg};
+#[cfg(feature = "lockup")]
+use crate::cw_vault_standard::extensions::lockup::{LockupExecuteMsg, LockupQueryMsg};
+
+use cosmwasm_schema::{cw_serde, QueryResponses};
+#[cfg(not(target_arch = "wasm32"))]
+use cosmwasm_std::Empty;
+use cosmwasm_std::{to_json_binary, Coin, CosmosMsg, StdResult, Uint128, WasmMsg};
+use schemars::JsonSchema;
+
+/// The default ExecuteMsg variants that all vaults must implement.
+/// This enum can be extended with additional variants by defining an extension
+/// enum and then passing it as the generic argument `T` to this enum.
+#[cw_serde]
+pub enum VaultStandardExecuteMsg<T = ExtensionExecuteMsg> {
+    /// Called to deposit into the vault. Native assets are passed in the funds
+    /// parameter.
+    Deposit {
+        /// The amount of base tokens to deposit.
+        amount: Uint128,
+        /// The optional recipient of the vault token. If not set, the caller
+        /// address will be used instead.
+        recipient: Option<String>,
+    },
+
+    /// Called to redeem vault tokens and receive assets back from the vault.
+    /// The native vault token must be passed in the funds parameter, unless the
+    /// lockup extension is called, in which case the vault token has already
+    /// been passed to ExecuteMsg::Unlock.
+    Redeem {
+        /// An optional field containing which address should receive the
+        /// withdrawn base tokens. If not set, the caller address will be
+        /// used instead.
+        recipient: Option<String>,
+        /// The amount of vault tokens sent to the contract. In the case that
+        /// the vault token is a Cosmos native denom, we of course have this
+        /// information in info.funds, but if the vault implements the
+        /// Cw4626 API, then we need this argument. We figured it's
+        /// better to have one API for both types of vaults, so we
+        /// require this argument.
+        amount: Uint128,
+    },
+
+    /// Called to execute functionality of any enabled extensions.
+    VaultExtension(T),
+}
+
+impl VaultStandardExecuteMsg {
+    /// Convert a [`VaultStandardExecuteMsg`] into a [`CosmosMsg`].
+    pub fn into_cosmos_msg(self, contract_addr: String, funds: Vec<Coin>) -> StdResult<CosmosMsg> {
+        Ok(WasmMsg::Execute {
+            contract_addr,
+            msg: to_json_binary(&self)?,
+            funds,
+        }
+        .into())
+    }
+}
+
+/// Contains ExecuteMsgs of all enabled extensions. To enable extensions defined
+/// outside of this crate, you can define your own `ExtensionExecuteMsg` type
+/// in your contract crate and pass it in as the generic parameter to ExecuteMsg
+#[cw_serde]
+pub enum ExtensionExecuteMsg {
+    #[cfg(feature = "keeper")]
+    Keeper(KeeperExecuteMsg),
+    #[cfg(feature = "lockup")]
+    Lockup(LockupExecuteMsg),
+    #[cfg(feature = "force-unlock")]
+    ForceUnlock(ForceUnlockExecuteMsg),
+}
+
+/// The default QueryMsg variants that all vaults must implement.
+/// This enum can be extended with additional variants by defining an extension
+/// enum and then passing it as the generic argument `T` to this enum.
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum VaultStandardQueryMsg<T = ExtensionQueryMsg>
+where
+    T: JsonSchema,
+{
+    /// Returns `VaultStandardInfoResponse` with information on the version of
+    /// the vault standard used as well as any enabled extensions.
+    #[returns(VaultStandardInfoResponse)]
+    VaultStandardInfo {},
+
+    /// Returns `VaultInfoResponse` representing vault requirements, lockup, &
+    /// vault token denom.
+    #[returns(VaultInfoResponse)]
+    Info {},
+
+    /// Returns `Uint128` amount of vault tokens that will be returned for the
+    /// passed in `amount` of base tokens.
+    ///
+    /// Allows an on-chain or off-chain user to simulate the effects of their
+    /// deposit at the current block, given current on-chain conditions.
+    ///
+    /// Must return as close to and no more than the exact amount of vault
+    /// tokens that would be minted in a deposit call in the same transaction.
+    /// I.e. Deposit should return the same or more vault tokens as
+    /// PreviewDeposit if called in the same transaction.
+    #[returns(Uint128)]
+    PreviewDeposit {
+        /// The amount of base tokens to preview depositing.
+        amount: Uint128,
+    },
+
+    /// Returns `Uint128` amount of base tokens that would be withdrawn in
+    /// exchange for redeeming `amount` of vault tokens.
+    ///
+    /// Allows an on-chain or off-chain user to simulate the effects of their
+    /// redeem at the current block, given current on-chain conditions.
+    ///
+    /// Must return as close to and no more than the exact amount of base tokens
+    /// that would be withdrawn in a redeem call in the same transaction.
+    #[returns(Uint128)]
+    PreviewRedeem {
+        /// The amount of vault tokens to preview redeeming.
+        amount: Uint128,
+    },
+
+    /// Returns the amount of assets managed by the vault denominated in base
+    /// tokens. Useful for display purposes, and does not have to confer the
+    /// exact amount of base tokens.
+    #[returns(Uint128)]
+    TotalAssets {},
+
+    /// Returns `Uint128` total amount of vault tokens in circulation.
+    #[returns(Uint128)]
+    TotalVaultTokenSupply {},
+
+    /// The amount of vault tokens that the vault would exchange for the amount
+    /// of assets provided, in an ideal scenario where all the conditions
+    /// are met.
+    ///
+    /// Useful for display purposes and does not have to confer the exact amount
+    /// of vault tokens returned by the vault if the passed in assets were
+    /// deposited. This calculation should not reflect the "per-user"
+    /// price-per-share, and instead should reflect the "average-user’s"
+    /// price-per-share, meaning what the average user should expect to see
+    /// when exchanging to and from.
+    #[returns(Uint128)]
+    ConvertToShares {
+        /// The amount of base tokens to convert to vault tokens.
+        amount: Uint128,
+    },
+
+    /// Returns the amount of base tokens that the Vault would exchange for
+    /// the `amount` of vault tokens provided, in an ideal scenario where all
+    /// the conditions are met.
+    ///
+    /// Useful for display purposes and does not have to confer the exact amount
+    /// of assets returned by the vault if the passed in vault tokens were
+    /// redeemed. This calculation should not reflect the "per-user"
+    /// price-per-share, and instead should reflect the "average-user’s"
+    /// price-per-share, meaning what the average user should expect to see
+    /// when exchanging to and from.
+    #[returns(Uint128)]
+    ConvertToAssets {
+        /// The amount of vault tokens to convert to base tokens.
+        amount: Uint128,
+    },
+
+    /// Handle queries of any enabled extensions.
+    #[returns(Empty)]
+    VaultExtension(T),
+}
+
+/// Contains QueryMsgs of all enabled extensions. To enable extensions defined
+/// outside of this crate, you can define your own `ExtensionQueryMsg` type
+/// in your contract crate and pass it in as the generic parameter to QueryMsg
+#[cw_serde]
+pub enum ExtensionQueryMsg {
+    #[cfg(feature = "keeper")]
+    Keeper(KeeperQueryMsg),
+    #[cfg(feature = "lockup")]
+    Lockup(LockupQueryMsg),
+}
+
+/// Struct returned from QueryMsg::VaultStandardInfo with information about the
+/// used version of the vault standard and any extensions used.
+///
+/// This struct should be stored as an Item under the `vault_standard_info` key,
+/// so that other contracts can do a RawQuery and read it directly from storage
+/// instead of needing to do a costly SmartQuery.
+#[cw_serde]
+pub struct VaultStandardInfoResponse {
+    /// The version of the vault standard used. A number, e.g. 1, 2, etc.
+    pub version: u16,
+    /// A list of vault standard extensions used by the vault.
+    /// E.g. ["lockup", "keeper"]
+    pub extensions: Vec<String>,
+}
+
+/// Returned by QueryMsg::Info and contains information about this vault
+#[cw_serde]
+pub struct VaultInfoResponse {
+    /// The token that is accepted for deposits, withdrawals and used for
+    /// accounting in the vault. The denom if it is a native token and the
+    /// contract address if it is a cw20 token.
+    pub base_token: String,
+    /// Vault token. The denom if it is a native token and the contract address
+    /// if it is a cw20 token.
+    pub vault_token: String,
+}

--- a/smart-contracts/osmosis/packages/quasar-types/src/lib.rs
+++ b/smart-contracts/osmosis/packages/quasar-types/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod abstract_sdk;
 pub mod callback;
 pub mod curve;
+pub mod cw_vault_multi_standard;
+pub mod cw_vault_standard;
 pub mod error;
 pub mod ibc;
 pub mod ica;


### PR DESCRIPTION
This PR moves the code from quasar-finance/cw-vault-extension into the quasar-types package. 